### PR TITLE
help people contribute by getting the link right...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-docs
+cf-docs
 ====
 
-This is the Cloud Foundry documentation - including information about running and managing applications on Cloud Foundry, and setting up your own Cloud Foundry instance with VCAP and BOSH. The repository also feeds [cloudfoundry.github.com](http://cloudfoundry.github.com) using [Github Pages](http://pages.github.com/) and [Middleman](http://middlemanapp.com/).
+This is the documentation for the Cloud Foundry project - including information about running and managing applications on Cloud Foundry, and setting up your own Cloud Foundry instance with VCAP and BOSH. 
+
+This repository also feeds [cloudfoundry.github.com](http://cloudfoundry.github.com) using [Github Pages](http://pages.github.com/) and [Middleman](http://middlemanapp.com/).
 
 If you have minor changes, you can contribute by forking this repository, modifying the files in `/source/docs`, and creating a GitHub pull request.
 
@@ -16,7 +18,7 @@ You can either contribute directly within Github or by cloning the repository to
 These docs are rendered using [middleman](https://github.com/middleman/middleman). To pull down the raw documentation project and view the docs on your local machine using middleman:
 
 ```
-git clone https://github.com/cloudfoundry/docs.git cloudfoundry-docs
+git clone https://github.com/cloudfoundry/cf-docs.git cloudfoundry-docs
 cd cloudfoundry-docs
 bundle
 middleman server
@@ -28,18 +30,21 @@ Then view [http://0.0.0.0:4567](http://0.0.0.0:4567) in your browser.
 
 ### Twitter
 
-* Follow the [@cloudfoundry](https://twitter.com/cloudfoundry) twitter account for retweets of blogs and news from the world of Cloud Foundry
+* Follow the [@cloudfoundry](https://twitter.com/cloudfoundry) Twitter account for retweets of blogs and news from the world of Cloud Foundry
+* Search the [#cloudfoundry](https://twitter.com/search/realtime?q=%23cloudfoundry) hashtag to follow discussions about Cloud Foundry
 
 ### Discussion Groups
 
-* [Using Cloud Foundry](http://stackoverflow.com/questions/tagged/cloudfoundry)
+* [Using Cloud Foundry](http://stackoverflow.com/questions/tagged/cloudfoundry) (development-related questions)
 * [Running / Setting up Cloud Foundry](https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups#!forum/vcap-dev)
 * [Using BOSH](https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups#!forum/bosh-users)
 * [Running / Setting up BOSH](https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups#!forum/bosh-dev)
 
+There is also a #cloudfoundry IRC channel on the Freenode network, but that may be less-frequently monitored by members of the core team.
+
 ### Bugs
 
-When you are getting started with Cloud Foundry, and are still learning your way around the Cloud Foundry repositories, you can raise bugs with [cloudfoundry.atlassian.net](http://cloudfoundry.atlassian.net/).
+When you are getting started with Cloud Foundry, and are still learning your way around the repositories, you can raise bugs with [cloudfoundry.atlassian.net](http://cloudfoundry.atlassian.net/).
 
 As you grow more experienced, you will discover that many of the sub-projects of Cloud Foundry have their own ticket systems via each project's GitHub Issues.
 

--- a/source/docs/running/micro_cloud_foundry/developing_cf.html.md
+++ b/source/docs/running/micro_cloud_foundry/developing_cf.html.md
@@ -2,29 +2,24 @@
 title: Developing Cloud Foundry with Micro Cloud Foundry
 ---
 
-This document describes an experimental workflow for Cloud Foundry component
-development by editing code locally and rsyncing it to a running Micro Cloud
-Foundry.
+This document describes an experimental workflow for Cloud Foundry component development by editing code locally and rsync'ing it to a running Micro Cloud Foundry.
 
 # Setup
 
-Download and unzip a test build of MCF with ng components:
-
-http://download3.vmware.com/cloudfoundry/micro/alpha/micro-demo.zip
+Download and unzip a test build of MCF with NG components [here](http://download3.vmware.com/cloudfoundry/micro/alpha/micro-demo.zip)
 
 Start the VM in Fusion or Workstation.
 
 Get the URL of the Micro Cloud from the VM console and open it in a browser.
 
 Set the password, private hostname (make up a fake domain) and choose
-DHCP. Wait about 5 minutes while the jobs are deployed. To watch the status,
-ssh to the micro cloud with username root and the password you set and run:
+DHCP. Wait about 5 minutes while the jobs are deployed. To watch the status, ssh to the micro cloud with username root and the password you set and run:
 
     watch -d monit summary
 
 ## Resolver setup
 
-On OSX, set up a custom resolver for your fake domain:
+On OS X, set up a custom resolver for your fake domain:
 
 Create /etc/resolver/your_domain with these contents:
 
@@ -56,7 +51,7 @@ vmc push a test app.
 
 Proof of concept development workflow:
 
-Set up continuous rsync between your local machine and Micro Cloud:
+Set up continuous rsync between your local machine and Micro Cloud (you can install the `brew` command using [OS X homebrew](http://mxcl.github.com/homebrew/)):
 
     ssh-copy-id root@<your domain>
 

--- a/source/docs/using/index.html.md
+++ b/source/docs/using/index.html.md
@@ -8,7 +8,7 @@ This section of the Cloud Foundry documentation is for developers pushing applic
 
 * [Deploying Apps](deploying-apps/index.html)
 
-  * [Java / JVM based](deploying-apps/jvm/index.html)
+  * [Java / JVM-based](deploying-apps/jvm/index.html)
 
   * [Node.js](deploying-apps/javascript/index.html)
 

--- a/source/docs/using/managing-apps/libs/index.html.md
+++ b/source/docs/using/managing-apps/libs/index.html.md
@@ -8,3 +8,5 @@ Coming soon...
 
 * Ruby gem (cloudfoundry-client)
 
+* Node.js module (cf-runtime) see http://blog.cloudfoundry.com/2012/08/21/new-runtime-module-for-node-js-applications/
+

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3,7 +3,12 @@ title: Welcome to Cloud Foundry Documentation
 ---
 
 This set of materials will replace all Cloud Foundry documentation, for cloudfoundry.com, vcap, and bosh, in Q1 of 2013.
-This information is forward looking and favors 'next generation' components which may not be applicable to existing Cloud Foundry installations. For a look at our roadmap - go [here](docs/roadmap.html).
+
+This information is forward-looking and favors 'next generation' components which may not be applicable to existing Cloud Foundry installations. 
+
+Docs are a work in progress and we welcome your [contributions](http://github.com/cloudfoundry/cf-docs).
+
+For a look at our roadmap - go [here](docs/roadmap.html).
 
 ## [Using Cloud Foundry](docs/using/index.html)
 
@@ -11,7 +16,7 @@ For developers pushing applications to Cloud Foundry.
 
 * [Deploying Apps](docs/using/deploying-apps/index.html)
 
-  * [Java / jvm based](docs/using/deploying-apps/jvm/index.html)
+  * [Java / JVM-based](docs/using/deploying-apps/jvm/index.html)
 
   * [Node.js](docs/using/deploying-apps/javascript/index.html)
 
@@ -28,7 +33,6 @@ For developers pushing applications to Cloud Foundry.
   * [Build tools](docs/using/managing-apps/build-tools/index.html)
 
   * [Libraries](docs/using/managing-apps/libs/index.html)
-
 
 * [Working with Services](docs/using/working-with-services/index.html)
 
@@ -68,4 +72,4 @@ For dev/ops people managing instances of Cloud Foundry.
 * [Monitoring Cloud Foundry](docs/running/monitoring/index.html)
 
 
-Docs are a work in progress and we welcome your [help](http://github.com/cloudfoundry/docs).
+


### PR DESCRIPTION
Fixed issue where the "contribute to docs" link was pointing to an
non-existent Github repo.
Added IRC channel info.
Clarified that StackOverflow is best used for dev-type questions.
Formatting cleanups.
Added placeholder for cf-runtime node library
