### PR TITLE
Add community section

### DIFF
--- a/source/docs/community/consulting.html.md
+++ b/source/docs/community/consulting.html.md
@@ -1,0 +1,5 @@
+---
+title: Consulting
+---
+
+TODO: Add a list of vendors offering consulting services around Cloud Foundry

--- a/source/docs/community/contrib.html.md
+++ b/source/docs/community/contrib.html.md
@@ -1,0 +1,7 @@
+---
+title: Contrib
+---
+
+A [list of 3rd party extensions, scripts and tools created by the Cloud Foundry community](http://cf-docs-contrib.cloudfoundry.com). 
+
+_These are not endorsed or supported by the core Cloud Foundry team in any way._

--- a/source/docs/community/hosting-providers.html.md
+++ b/source/docs/community/hosting-providers.html.md
@@ -1,0 +1,5 @@
+---
+title: Hosting providers
+---
+
+TODO: Add a list of providers offering hosting

--- a/source/docs/community/index.html.md
+++ b/source/docs/community/index.html.md
@@ -1,0 +1,9 @@
+---
+title: Community
+---
+
+Extensions, tools and services provided by the Cloud Foundry community.
+
+  * [Hosting providers](hosting-providers.html)
+  * [Consulting](consulting.html)
+  * [Contrib](contrib.html)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -46,7 +46,6 @@ For developers pushing applications to Cloud Foundry.
 
   * [RabbitMQ](docs/using/working-with-services/rabbit.html)
 
-
 ## [Running Cloud Foundry](docs/running/index.html)
 
 For dev/ops people managing instances of Cloud Foundry.
@@ -71,5 +70,10 @@ For dev/ops people managing instances of Cloud Foundry.
 
 * [Monitoring Cloud Foundry](docs/running/monitoring/index.html)
 
+## [Community](docs/community/index.html)
 
+Extensions, tools and services provided by the Cloud Foundry community.
 
+  * [Hosting providers](docs/community/hosting-providers.html)
+  * [Consulting](docs/community/consulting.html)
+  * [Contrib](docs/community/contrib.html)


### PR DESCRIPTION
I'd like to propose the following community section in the docs that contains links to resources made by the Cloud Foundry community.

In specific; please note the link to [CF Contrib](https://github.com/mrdavidlaing/cf-docs/pull/new/cloudfoundry:master...mrdavidlaing:add_community_section#L1R5) - an "unofficial" site listing bits and pieces made available & curated by the CF Community.
