### PR TITLE
Relax middleman dependency (3.0.10 was yanked)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source :rubygems
 
-gem "middleman", "~>3.0.10"
+gem "middleman", "~>3.0"
 gem "redcarpet", "~>2.2.2"
 
 gem 'middleman-syntax'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.11)
+    activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
     chunky_png (1.2.7)
@@ -16,8 +16,9 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.3.1)
-    fssm (0.2.9)
-    haml (3.1.7)
+    fssm (0.2.10)
+    haml (4.0.0)
+      tilt
     hike (1.2.1)
     http_router (0.10.2)
       rack (>= 1.0.0)
@@ -26,11 +27,11 @@ GEM
     listen (0.5.3)
     maruku (0.6.1)
       syntax (>= 1.0.0)
-    middleman (3.0.10)
-      middleman-core (= 3.0.10)
-      middleman-more (= 3.0.10)
+    middleman (3.0.11)
+      middleman-core (= 3.0.11)
+      middleman-more (= 3.0.11)
       middleman-sprockets (~> 3.0.6)
-    middleman-core (3.0.10)
+    middleman-core (3.0.11)
       activesupport (~> 3.2.6)
       bundler (~> 1.1)
       listen (~> 0.5.2)
@@ -40,7 +41,7 @@ GEM
       rb-inotify (~> 0.8.8)
       thor (~> 0.15.4)
       tilt (~> 1.3.1)
-    middleman-more (3.0.10)
+    middleman-more (3.0.11)
       coffee-script (~> 2.2.0)
       coffee-script-source (~> 1.3.3)
       compass (>= 0.12.2)
@@ -48,7 +49,7 @@ GEM
       haml (>= 3.1.6)
       i18n (~> 0.6.0)
       maruku (~> 0.6.0)
-      middleman-core (= 3.0.10)
+      middleman-core (= 3.0.11)
       padrino-helpers (= 0.10.7)
       sass (>= 3.1.20)
       uglifier (~> 1.2.6)
@@ -59,7 +60,7 @@ GEM
     middleman-syntax (1.0.1)
       middleman-core (~> 3.0)
       pygments.rb (~> 0.3)
-    multi_json (1.5.0)
+    multi_json (1.6.0)
     padrino-core (0.10.7)
       activesupport (~> 3.2.0)
       http_router (~> 0.10.2)
@@ -73,7 +74,7 @@ GEM
     pygments.rb (0.3.7)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
-    rack (1.4.4)
+    rack (1.4.5)
     rack-protection (1.3.2)
       rack
     rack-test (0.6.2)
@@ -83,9 +84,9 @@ GEM
       ffi (>= 0.5.0)
     redcarpet (2.2.2)
     sass (3.2.5)
-    sinatra (1.3.3)
-      rack (~> 1.3, >= 1.3.6)
-      rack-protection (~> 1.2)
+    sinatra (1.3.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.3)
       tilt (~> 1.3, >= 1.3.3)
     sprockets (2.4.5)
       hike (~> 1.2)
@@ -109,6 +110,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman (~> 3.0.10)
+  middleman (~> 3.0)
   middleman-syntax
   redcarpet (~> 2.2.2)


### PR DESCRIPTION
Middleman 3.0.10 was yanked from rubygems and app failed to start
