### PR TITLE
Automate Inception VM Preparation

### DIFF
--- a/source/docs/running/deploying-cf/openstack/install_microbosh_openstack.md
+++ b/source/docs/running/deploying-cf/openstack/install_microbosh_openstack.md
@@ -254,5 +254,4 @@ Copy the below content and paste it in `micro-bosh.yml`
     Enter password: *****
     Logged in as `admin'
 
-**Note:** It will ask for the username and password, enter admin for both.
-**Note:** Create a new BOSH user - the 'admin' will be automatically deleted
+**Note:** It will ask for the username and password, enter admin for both.Also, Create a new BOSH user - the 'admin' will be automatically deleted

--- a/source/docs/running/deploying-cf/openstack/install_microbosh_openstack.md
+++ b/source/docs/running/deploying-cf/openstack/install_microbosh_openstack.md
@@ -255,3 +255,4 @@ Copy the below content and paste it in `micro-bosh.yml`
     Logged in as `admin'
 
 **Note:** It will ask for the username and password, enter admin for both.
+**Note:** Create a new BOSH user - the 'admin' will be automatically deleted


### PR DESCRIPTION
Why don't we use Dr. Nic's script to prepare Inception VM instead of installing everything manually. We can accomplish steps 3 to 6 in (source/docs/running/deploying-cf/openstack/install_microbosh_openstack.md) with a single script.
