### PR TITLE
Add Google Custom Search box

### DIFF
--- a/source/javascripts/google-custom-search.js
+++ b/source/javascripts/google-custom-search.js
@@ -1,0 +1,12 @@
+/* Google Custom Search
+* Custom search set up under mrdavidlaing@gmail.com - email for details of sites indexed */
+(function() {
+  var cx = '011496095511695732182:yllu-lq9bfq'; 
+  var gcse = document.createElement('script');
+  gcse.type = 'text/javascript';
+  gcse.async = true;
+  gcse.src = (document.location.protocol == 'https' ? 'https:' : 'http:') +
+      '//www.google.com/cse/cse.js?cx=' + cx;
+  var s = document.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(gcse, s);
+})();

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -10,7 +10,7 @@
     <title><%= data.page.title || "Cloud Foundry Docs" %></title>
     
     <%= stylesheet_link_tag "style" %>
-    <%= javascript_include_tag  "all" %>
+   
     <!--[if IE 8]>
     <style>
         body  {background-color:#85bfe4;background-image:none;}
@@ -23,6 +23,9 @@
       <img alt="Fork me on GitHub" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png">
     </a>
     <div id="main">
+      <div id="search-box">
+          <gcse:searchbox-only></gcse:searchbox-only> 
+      </div>
       <div id="logo">
         <a href="http://www.cloudfoundry.com">
           <img src="/images/logo_cloudfoundry.png" height="57">
@@ -59,5 +62,7 @@
       VMware, Inc. All rights reserved.
       </p>
     </div>
+    <%= javascript_include_tag  "all" %>
+    <%= javascript_include_tag  "google-custom-search" %>
   </body>
 </html>

--- a/source/stylesheets/style.css
+++ b/source/stylesheets/style.css
@@ -2,6 +2,17 @@
 /* Global Reset & Standards ---------------------- */
 *, *:before, *:after { -webkit-box-sizing: border-box; -moz-box-sizing: border-box; box-sizing: border-box; }
 
+#search-box {
+  position:absolute; 
+  margin-left: 850px; 
+  width:330px;
+}
+
+.gsc-search-box * { 
+  -webkit-box-shadow: none; -moz-box-shadow: none; box-shadow: none;
+  -webkit-box-sizing: content-box; -moz-box-sizing: content-box; box-sizing: content-box; 
+}
+
 * {
   margin: 0;
 }


### PR DESCRIPTION
Adds a Google Custom Search box to the header:

![Screeny Shot 10 Mar 2013 00 51 12](https://f.cloud.github.com/assets/227505/240475/a747b734-891c-11e2-9b1f-661a63c0516e.png)

Search is associated with mrdavidlaing@gmail.com's account; but other Google accounts can be given permissions to edit what is indexed etc.

Currently this custom search indexes:
1. http://cloudfoundry.github.com/* 
2. https://github.com/mrdavidlaing/cf-docs-contrib/wiki/*  
3. https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups#!forum/bosh-dev  
4. https://groups.google.com/a/cloudfoundry.org/forum/?fromgroups#!forum/vcap-dev  
