### PR TITLE
Renamed VMC to CF

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
            Version 2.0, January 2004
         http://www.apache.org/licenses/
 
-		
+
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
    1. Definitions.
@@ -206,8 +206,8 @@
 CF Docs 09012012
 
 CF Docs 09012012 : includes a number of subcomponents with
-separate copyright notices and license terms.  The product that 
-includes this file does not necessarily use all the open source 
+separate copyright notices and license terms.  The product that
+includes this file does not necessarily use all the open source
 subcomponents referred to below. Your use of the source
 code for the these subcomponents is subject to the terms and
 conditions of the following licenses.
@@ -234,7 +234,7 @@ SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
    >>> sinatra-1.3.1
    >>> spruz-0.2.13
    >>> terminal-table-1.4.4
-   >>> vmc-0.3.14
+   >>> cf-0.3.14
 
 
 
@@ -243,8 +243,8 @@ SECTION 2: Apache License, V2.0
    >>> addressable-2.2.6
    >>> addressable-2.2.8
    >>> cfoundry-0.3.40
-   >>> manifests-vmc-plugin-0.4.8
-   >>> tunnel-dummy-vmc-plugin-0.0.1
+   >>> manifests-cf-plugin-0.4.8
+   >>> tunnel-dummy-cf-plugin-0.0.1
 
 
 
@@ -692,7 +692,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Copyright (c) 2009, Park Heesob
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 * Redistributions of source code must retain the above copyright notice, this
@@ -700,19 +700,19 @@ modification, are permitted provided that the following conditions are met:
 * Redistributions in binary form must reproduce the above copyright notice
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
-* Neither the name of Park Heesob nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
+* Neither the name of Park Heesob nor the names of its contributors
+  may be used to endorse or promote products derived from this software
   without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
@@ -801,7 +801,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED AS IS, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> vmc-0.3.14
+>>> cf-0.3.14
 
 Copyright (c) 2010-2011 VMware Inc, All Rights Reserved
 
@@ -858,24 +858,24 @@ limitations under the License.
 License: Apache 2.0
 
 
->>> manifests-vmc-plugin-0.4.8
+>>> manifests-cf-plugin-0.4.8
 
-VMC-Lib
+cfoundry
 Copyright (c) 2012 VMware, Inc. All Rights Reserved.
 
 VMware copyrighted code, is licensed to you under the Apache License, Version 2.0 (the "License").
 
-In addition to the VMware copyrighted code, VMC includes a number of components with separate copyright notices and license terms. Your use of these components is subject to the terms and conditions of the component's license, as noted in the LICENSE file.
+In addition to the VMware copyrighted code, CF includes a number of components with separate copyright notices and license terms. Your use of these components is subject to the terms and conditions of the component's license, as noted in the LICENSE file.
 
 
->>> tunnel-dummy-vmc-plugin-0.0.1
+>>> tunnel-dummy-cf-plugin-0.0.1
 
-VMC-Lib
+cfoundry
 Copyright (c) 2012 VMware, Inc. All Rights Reserved.
 
 VMware copyrighted code, is licensed to you under the Apache License, Version 2.0 (the "License").
 
-In addition to the VMware copyrighted code, VMC includes a number of components with separate copyright notices and license terms. Your use of these components is subject to the terms and conditions of the component's license, as noted in the LICENSE file.
+In addition to the VMware copyrighted code, CF includes a number of components with separate copyright notices and license terms. Your use of these components is subject to the terms and conditions of the component's license, as noted in the LICENSE file.
 
 
 --------------- SECTION 3: GNU General Public License, V3.0 ----------
@@ -916,7 +916,7 @@ Ruby Clause-6 is applicable to the following component(s).
 
 >>> json_pure-1.5.4
 
-[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE RUBYCLAUSE-6 LICENSE.  PLEASE SEE BELOW FOR THE FULL TEXT OF THE RUBYCLAUSE-6 LICENSE. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.] 
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE RUBYCLAUSE-6 LICENSE.  PLEASE SEE BELOW FOR THE FULL TEXT OF THE RUBYCLAUSE-6 LICENSE. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
 
 JSON-JRuby is copyrighted free software by Daniel Luz <mernen at gmail dot com>,
@@ -966,9 +966,9 @@ version 2 (see the file GPL), or the conditions below:
      For the list of those files and their copying conditions, see the
      file LEGAL.
 
-  5. The scripts and library files supplied as input to or produced as 
+  5. The scripts and library files supplied as input to or produced as
      output from the software do not automatically fall under the
-     copyright of the software, but belong to whomever generated them, 
+     copyright of the software, but belong to whomever generated them,
      and may be sold commercially, and may be aggregated with this
      software.
 
@@ -1063,9 +1063,9 @@ You can redistribute it and/or modify it under either the terms of the
      For the list of those files and their copying conditions, see the
      file LEGAL.
 
-  5. The scripts and library files supplied as input to or produced as 
+  5. The scripts and library files supplied as input to or produced as
      output from the software do not automatically fall under the
-     copyright of the software, but belong to whomever generated them, 
+     copyright of the software, but belong to whomever generated them,
      and may be sold commercially, and may be aggregated with this
      software.
 
@@ -1128,9 +1128,9 @@ You can redistribute it and/or modify it under either the terms of the
      For the list of those files and their copying conditions, see the
      file LEGAL.
 
-  5. The scripts and library files supplied as input to or produced as 
+  5. The scripts and library files supplied as input to or produced as
      output from the software do not automatically fall under the
-     copyright of the software, but belong to whomever generated them, 
+     copyright of the software, but belong to whomever generated them,
      and may be sold commercially, and may be aggregated with this
      software.
 
@@ -1194,9 +1194,9 @@ You can redistribute it and/or modify it under either the terms of the
      For the list of those files and their copying conditions, see the
      file LEGAL.
 
-  5. The scripts and library files supplied as input to or produced as 
+  5. The scripts and library files supplied as input to or produced as
      output from the software do not automatically fall under the
-     copyright of the software, but belong to whomever generated them, 
+     copyright of the software, but belong to whomever generated them,
      and may be sold commercially, and may be aggregated with this
      software.
 
@@ -1206,7 +1206,7 @@ You can redistribute it and/or modify it under either the terms of the
      PURPOSE.
 
 
-=============== APPENDIX. Standard License Files ============== 
+=============== APPENDIX. Standard License Files ==============
 
 
 
@@ -1220,7 +1220,7 @@ You can redistribute it and/or modify it under either the terms of the GPL
      software without restriction, provided that you duplicate all of the
      original copyright notices and associated disclaimers.
 
- 
+
   2. You may modify your copy of the software in any way, provided that
      you do at least ONE of the following:
 
@@ -1237,7 +1237,7 @@ You can redistribute it and/or modify it under either the terms of the GPL
 
        d) make other distribution arrangements with the author.
 
- 
+
   3. You may distribute the software in object code or executable
      form, provided that you do at least ONE of the following:
 
@@ -1253,7 +1253,7 @@ You can redistribute it and/or modify it under either the terms of the GPL
 
        d) make other distribution arrangements with the author.
 
- 
+
   4. You may modify and include the part of the software into any other
      software (possibly commercial).  But some files in the distribution
      are not written by the author, so that they are not under this terms.
@@ -1262,7 +1262,7 @@ You can redistribute it and/or modify it under either the terms of the GPL
      files under the ./missing directory.  See each file for the copying
      condition.
 
- 
+
   5. The scripts and library files supplied as input to or produced as
      output from the software do not automatically fall under the
      copyright of the software, but belong to whomever generated them,
@@ -1275,9 +1275,9 @@ You can redistribute it and/or modify it under either the terms of the GPL
      WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
      PURPOSE.
 
- 
 
- 
+
+
 
 --------------- SECTION 2: GNU General Public License, V3.0 -----------
 

--- a/source/docs/reference/cc-api.html.md
+++ b/source/docs/reference/cc-api.html.md
@@ -6,105 +6,105 @@ _This documents the v2 version of the API.  v1 is unofficially documented at htt
 
 Principles of Operation
 =======================
- 
+
 Overview
 --------
- 
+
 The Cloud Foundry V2 family of APIs follow RESTful principles.
 The primary goal of the V2 API is to support the new entities in
 the Team Edition release, and to address the shortcomings of V1 in terms of features and consistency.
 
 The specific high level goals are as follows:
- 
+
 * **Consistency** across all resource URLs, parameters, request/response
   bodies, and error responses.
- 
+
 * **Partial updates** of a resource can be performed by providing a subset of the resources' attributes.  This is in contrast to the V1 API which required a read-modify-write cycle to update an attribute.
- 
+
 * **Pagination** support for each of the collections.
- 
+
 * **Filtering** support for each of the collections.
- 
+
 Authentication
 --------------
- 
+
 Authentication is performed by providing a UAA Token in the _Authorization_ HTTP header.
- 
+
 **TBD:** insert snippet from Dale about the responses if the Token isn't provided, or if is invalid, expired, etc.
- 
+
 Versioning
 ----------
- 
+
 The API version is specified in the URL, e.g. `POST /v2/foo_bars` to
 create a new FooBar using version 2 of the API.
- 
+
 Debugging
 ---------
- 
+
 The V2 API endpoints may optionally return a GUID in the `X-VCAP-Request-ID`
 HTTP header.  The API endpoint will ideally log this GUID on all log lines and pass it to associated systems to assist with cross component log collation.
- 
+
 Basic Operations
 ----------------
- 
+
 Operations on resources follow standard REST conventions.  Requests and
 responses for resources are JSON-encoded.  Error responses are also JSON
 encoded.
- 
+
 ### Common Attributes in Response Bodies
- 
+
 Response bodies have 2 components, `metadata` and `entity` sections.
- 
+
 The following attributes are contained in the `metadata` section:
- 
+
 | Attribute  | Description                                                                         |
 | :---------  | :-----------                                                                         |
 | guid       | Stable id for the resource.                                                         |
 | url        | URL for the resource.                                                               |
 | created_at | Date/Timestamp the resource was created, e.g. "2012-01-01 13:42:00 -0700"           |
 | updated_at | Date/Timestamp the resource was updated.  null if the resource has not been updated |
- 
- 
+
+
 ### Creating Resources
- 
+
 `POST /v2/foo_bars` creates a FooBar.
- 
+
 The attributes for new FooBar are specified in a JSON-encoded request body.
- 
+
 A successful `POST` results in HTTP 201 with the `Location`
 header set to the URL of the newly created resource.  The API endpoint should
 return the Etag HTTP header for later use by the client
 in support of opportunistic concurrency.
- 
+
 The attributes for the FooBar are returned in a JSON-encoded response body.
- 
+
 ### Reading Resources
- 
+
 `GET /v2/foo_bars/:guid` returns the attributes for a specific
 FooBar.
- 
+
 A successful `GET` results in HTTP 200.  The API endpoint should set the
 Etag HTTP header for later use in opportunistic concurrency.
- 
+
 The attributes for the FooBar are returned in a JSON-encoded response body.
- 
+
 ### Listing Resources
- 
+
 `GET /v2/foo_bars` lists the FooBars.
- 
+
 Successful `GET` requests return HTTP 200.
- 
+
 The attributes for the FooBar are returned in a JSON-encoded response body.
- 
+
 #### Pagination
- 
+
 All `GET` requests to collections are implicitly paginated, i.e. `GET
 /v2/foo_bars` initiates a paginated request/response across all FooBars.
- 
+
 ##### Pagination Response Attributes
- 
+
 A paginated response contains the following attributes:
- 
+
 | Attribute     | Description                                                                                       |
 | :---------     | :-----------                                                                                       |
 | total_results | Total number of results in the entire data set.                                                   |
@@ -112,31 +112,31 @@ A paginated response contains the following attributes:
 | prev_url      | URL used to fetch the previous set of results in the paginated response.  null on the first call. |
 | next_url      | URL used to fetch the next set of ressults in the paginated response.  null on the last call.     |
 | resources     | Array of resources as returned by a GET on the resource id.                                       |
- 
+
 The resources are expanded by default because in that is what is desired in the
 common use cases.
- 
+
 ##### Pagination Parameters
- 
+
 The following optional parameters may be specified in the initial GET, or
 included in the query string to `prev_url` or `next_url`.
- 
+
 | Parameter        | Description                                                                      |
 | ---------        | -----------                                                                      |
 | page             | Page from which to start iteration                                               |
 | results-per-page | Results to return per page                                                       |
 | urls-only        | If 1, only return a list of urls; do not expand metadata or resource attributes |
- 
+
 If the client is going to iterate through the entire dataset, they are
 encouraged to follow `next_url` rather than iterating by setting
 page and results-per-page.
- 
+
 Example:
- 
+
 Request: `GET /v2/foo_bars?results-per-page=2`
- 
+
 Response:
- 
+
 ```json
 {
   "total_results": 10029,
@@ -170,38 +170,38 @@ Response:
   ]
 }
 ```
- 
+
 #### Search/Filtering
- 
+
 Searching and Filtering are peformed via the `q` query parameter.  The value of
 the `q` parameter is a key value pair containing the resource attribute name
 and the query value, e.g: `GET /v2/foo_bars?q=name:some*` would return
 both records shown in the pagination example above.
- 
+
 String query values may contain a `*` which will be treated at a shell style
 glob.
- 
+
 Query values may also contain `>` or `<`, e.g. `GET /v2/foo_bars?q=instances:>2`.
- 
+
 The API endpoint may return an error if the resulting query performs an
 unindexed search.
- 
+
 ### Deleting Resources
- 
+
 `DELETE /v2/foo_bars/:guid` deletes a specific FooBar.
- 
+
 The caller may specify the `If-Match` HTTP header to enable opportunistic
 concurrency.  This is not required.  If there is an opportunistic concurrency
 failure, the API endpoint should return HTTP 412.
- 
+
 A successful `DELETE` operation results in a 204.
- 
+
 ### Updating Resources
- 
+
 `PUT` differs from standard convention.  In order to avoid a read-modify-write
 cycle when updating a single attribute, `PUT` is handled as if the `PATCH` verb
 were used.  Specifically, if a resource with URL `/v2/foo_bars/99` has attributes
- 
+
 ```json
 {
   "metadata": {
@@ -216,10 +216,10 @@ were used.  Specifically, if a resource with URL `/v2/foo_bars/99` has attribute
   }
 }
 ```
- 
+
 then a `PUT /v2/foo_bars/99` with a request body of `{"instances":3}` results
 in a resource with the following attributes
- 
+
 ```json
 {
   "metadata": {
@@ -234,115 +234,115 @@ in a resource with the following attributes
   }
 }
 ```
- 
+
 A successful `PUT` results in HTTP 200.
- 
+
 The caller may specify the `If-Match` HTTP header to enable opportunistic
 concurrency.  This is not required.  If there is an opportunistic concurrency
 failure, the API endpoint should return HTTP 412.
- 
+
 The attributes for the updated FooBar are returned in a JSON-encoded response body.
- 
+
 Note: version 3 of this API might require `PUT` to contain the full list of required
 attributes and such partial updates might only be supported via the HTTP
 `PATCH` verb.
- 
+
 Associations
 ------------
- 
+
 ### N-to-One
- 
+
 #### Reading N-to-One Associations
- 
+
 N-to-one relationships are indicated by an id and url attribute for the other
 resource.  For example, if a FooBar has a 1-to-1 relationship with a Baz,
 a `GET /v2/FooBar/:guid` will return the following attributes related to
 the associated Baz (other attributes omitted)
- 
+
 ```json
 {
   "baz_guid": 5,
   "baz_url": "/v2/bazs/5"
 }
 ```
- 
+
 #### Setting N-to-One Associations
- 
+
 Setting an n-to-one association is done during the initial `POST` for the
 resource or during an update via `PUT`.  The caller only specifies the id,
 not the url.  For example, to update change the Baz associated with the FooBar
 in the example above, the caller could issue a
 `PUT /v2/FooBar/:guid` with a body of `{ "baz_guid": 10 }`.  To disassociate
 the resources, set the id to `null`.
- 
+
 ### N-to-Many
- 
+
 #### Reading N-to-Many Associations
- 
+
 N-to-many relationships may be
 N-to-Many relationships are indicated by a url attribute for the other
 collection of resources.  For example, if a FooBaz has multiple Bars, a
 `GET /v2/FooBaz/:id` will return the following attribute (other
 attributes omitted)
- 
+
 ```json
 {
   "bars_url": "/v2/foo_baz/bars"
 }
 ```
- 
+
 The URL will initiated a paginated response.
- 
+
 #### Setting N-to-Many Associations
- 
+
 Setting an n-to-many association is done during the initial `POST` for the
 resource, during an update via `PUT`.
- 
+
 To create the association during a `POST` or to edit it with a `PUT`, supply a
 an array of ids.  For example, in the FooBaz has multiple Bars example
 above, a caller could issue a `POST /v2/foo_baz` with a body of `{ "bar_guid": [1,
 5, 10]}` to make an initial association of the new FooBaz with Bars with ids 1,
 5 and 10 (other attributes omitted).  Similarly, a `PUT` will update the
 associations between the resources to only those provided in the list.
- 
+
 Adding and removing elements from a large collection would be onerous if the
 entire list had to be provided every time.
- 
+
 A `PUT /v2/foo_baz/1/bars/2` will add bar with id 2 to foobaz with id 1.
- 
+
 A `DELETE /v2/foo_baz/1/bars/2` will remove bar with id 2 to from foobaz with
 id 1.
- 
+
 Batching incremental updates may be supported in the future.
 To control how the list of ids are added to the collection, supply the
 following query parameter `collection-method=add`, `collection-method=replace`, or
 `collection-method=delete`.  If the collection-method is not supplied,
 it defaults to replace.  NOTE: this is a future design note.
 collection-method is not currently supported.
- 
- 
+
+
 ### Inlining Relationships
- 
+
 There are common Cloud Foundry use cases that would require a relatively high
 number of API calls if the relation URLs have to be fetched when traversing a
-set of resources, e.g. when performing the calls necessary to satisfy a `vmc
+set of resources, e.g. when performing the calls necessary to satisfy a `cf
 apps` command line call.  In these cases, the caller intends to walk the entire
 tree of relationships.
- 
+
 To inline relationships, the caller may specify a `inline-relations-depth` query
 parameter for a `GET` request.  A value of 0 results in the default behaviour of
 not inlining any of the relations and only URLs as described above are
 returned.  A value of N > 0 results in the direct expansion of relations
 inline in the response, but URLs are provided for the next level of relations.
- 
+
 For example, in the request below a FooBar has a to-many relationship to Bars
 and Bars has a to-one relationship with a Baz.  Setting the
 `inline-relations-depth=1` results in bars being expanded but not baz.
- 
+
 Request: `GET /v2/FooBar/5?inline-relations-depth=1`
- 
+
 Response:
- 
+
 ```json
 {
   "metadata": {
@@ -371,7 +371,7 @@ Response:
   }
 }
 ```
- 
+
 Specifying `inline-releations-depth` > 1 should not result in an circular
 expansion of resources.  For example, if there is a bidirectional relationship
 between two resources, e.g. an Organization has many Users and a User is a
@@ -380,46 +380,46 @@ member of many Organizations, then the response to `GET
 should not expand the Organizations a User belongs to.  Doing so would result
 in an expansion loop.  The User expansion should provide a `organizations_url`
 instead.
- 
+
 Errors
 ------
- 
+
 Appropriate HTTP response codes are returned as part of the HTTP response
 header, i.e. 400 if the request body can not be parsed, 404 if an operation
 is requested on a resource that doesn't exist, etc.
- 
+
 In addition to the HTTP response code, an error response is returned in the
 response body.  The error response is JSON-encoded with the following
 attributes:
- 
+
 | Attribute    | Description                             |
 | ---------    | -----------                             |
 | code         | Unique numeric response code            |
 | descriptions | Human readable description of the error |
- 
+
 Actions
 -------
- 
+
 Actions are modeled as an update to desired state in the system, i.e.
 to start a FooBar resource with id 5 and set the instance count
 to 10, the caller would `PUT /v2/foo_bar/5` with a request body of
 `{ "state": "STARTED", "instances": 10 }`.
- 
+
 ## Organization
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Organizations
- 
+
 Resource URL: `GET /v2/organizations`
- 
+
 Returns a paginated response of Organizations.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -427,7 +427,7 @@ Returns a paginated response of Organizations.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributes |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * name
 * space_guid
@@ -435,31 +435,31 @@ The `q` query parameter may include the following `attribute-names`:
 * manager_guid
 * billing_manager_guid
 * auditor_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Organization is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -472,17 +472,17 @@ The schema for the `:entity` hash for Organization is:
 | managers_url          | String /HTTPS_URL_REGEX/                                     |
 | billing_managers_url  | String /HTTPS_URL_REGEX/                                     |
 | auditors_url          | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE Organization
- 
+
 Resource URL: `POST /v2/organizations`
- 
+
 Creates a Organization.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | name                  | required | String                                             |
@@ -493,25 +493,25 @@ Creates a Organization.
 | manager_guids         | optional | [String]                                           |
 | billing_manager_guids | optional | [String]                                           |
 | auditor_guids         | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Organization is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -524,28 +524,28 @@ The schema for the `:entity` hash for Organization is:
 | managers_url          | String /HTTPS_URL_REGEX/                                     |
 | billing_managers_url  | String /HTTPS_URL_REGEX/                                     |
 | auditors_url          | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE Organization
- 
+
 Resource URL: `PUT /v2/organizations`
- 
+
 Updates a Organization.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | name                  | optional | String                                             |
@@ -557,25 +557,25 @@ Updates a Organization.
 | manager_guids         | optional | [String]                                           |
 | billing_manager_guids | optional | [String]                                           |
 | auditor_guids         | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Organization is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -588,33 +588,33 @@ The schema for the `:entity` hash for Organization is:
 | managers_url          | String /HTTPS_URL_REGEX/                                     |
 | billing_managers_url  | String /HTTPS_URL_REGEX/                                     |
 | auditors_url          | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ Organization
- 
+
 Resource URL: `READ /v2/organizations/:guid`
- 
+
 Reads a Organization.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Organization is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -627,36 +627,36 @@ The schema for the `:entity` hash for Organization is:
 | managers_url          | String /HTTPS_URL_REGEX/                                     |
 | billing_managers_url  | String /HTTPS_URL_REGEX/                                     |
 | auditors_url          | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE Organization
- 
+
 Resource URL: `DELETE /v2/organizations/:guid`
- 
+
 Deletes a Organization.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## User
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Users
- 
+
 Resource URL: `GET /v2/users`
- 
+
 Returns a paginated response of Users.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -664,7 +664,7 @@ Returns a paginated response of Users.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributes |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * space_guid
 * organization_guid
@@ -673,31 +673,31 @@ The `q` query parameter may include the following `attribute-names`:
 * audited_organization_guid
 * managed_space_guid
 * audited_space_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for User is:
- 
+
 | name                              | schema                                                       |
 | --------------------------------- | ------------------------------------------------------------ |
 | guid                              | String                                                       |
@@ -711,17 +711,17 @@ The schema for the `:entity` hash for User is:
 | audited_organizations_url         | String /HTTPS_URL_REGEX/                                     |
 | managed_spaces_url                | String /HTTPS_URL_REGEX/                                     |
 | audited_spaces_url                | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE User
- 
+
 Resource URL: `POST /v2/users`
- 
+
 Creates a User.
- 
+
 #### Request Format:
- 
+
 | name                               | notes    | schema                                             |
 | ---------------------------------- | -------- | -------------------------------------------------- |
 | guid                               | required | String                                             |
@@ -734,25 +734,25 @@ Creates a User.
 | audited_organization_guids         | optional | [String]                                           |
 | managed_space_guids                | optional | [String]                                           |
 | audited_space_guids                | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for User is:
- 
+
 | name                              | schema                                                       |
 | --------------------------------- | ------------------------------------------------------------ |
 | guid                              | String                                                       |
@@ -766,28 +766,28 @@ The schema for the `:entity` hash for User is:
 | audited_organizations_url         | String /HTTPS_URL_REGEX/                                     |
 | managed_spaces_url                | String /HTTPS_URL_REGEX/                                     |
 | audited_spaces_url                | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE User
- 
+
 Resource URL: `PUT /v2/users`
- 
+
 Updates a User.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                               | notes    | schema                                             |
 | ---------------------------------- | -------- | -------------------------------------------------- |
 | guid                               | optional | String                                             |
@@ -800,25 +800,25 @@ Updates a User.
 | audited_organization_guids         | optional | [String]                                           |
 | managed_space_guids                | optional | [String]                                           |
 | audited_space_guids                | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for User is:
- 
+
 | name                              | schema                                                       |
 | --------------------------------- | ------------------------------------------------------------ |
 | guid                              | String                                                       |
@@ -832,33 +832,33 @@ The schema for the `:entity` hash for User is:
 | audited_organizations_url         | String /HTTPS_URL_REGEX/                                     |
 | managed_spaces_url                | String /HTTPS_URL_REGEX/                                     |
 | audited_spaces_url                | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ User
- 
+
 Resource URL: `READ /v2/users/:guid`
- 
+
 Reads a User.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for User is:
- 
+
 | name                              | schema                                                       |
 | --------------------------------- | ------------------------------------------------------------ |
 | guid                              | String                                                       |
@@ -872,36 +872,36 @@ The schema for the `:entity` hash for User is:
 | audited_organizations_url         | String /HTTPS_URL_REGEX/                                     |
 | managed_spaces_url                | String /HTTPS_URL_REGEX/                                     |
 | audited_spaces_url                | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE User
- 
+
 Resource URL: `DELETE /v2/users/:guid`
- 
+
 Deletes a User.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## Space
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Spaces
- 
+
 Resource URL: `GET /v2/spaces`
- 
+
 Returns a paginated response of Spaces.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -909,37 +909,37 @@ Returns a paginated response of Spaces.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * name
 * organization_guid
 * developer_guid
 * app_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Space is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -951,17 +951,17 @@ The schema for the `:entity` hash for Space is:
 | apps_url              | String /HTTPS_URL_REGEX/                                     |
 | domains_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE Space
- 
+
 Resource URL: `POST /v2/spaces`
- 
+
 Creates a Space.
- 
+
 #### Request Format:
- 
+
 | name                   | notes    | schema                                             |
 | ---------------------- | -------- | -------------------------------------------------- |
 | name                   | required | String                                             |
@@ -972,25 +972,25 @@ Creates a Space.
 | app_guids              | optional | [String]                                           |
 | domain_guids           | optional | [String]                                           |
 | service_instance_guids | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Space is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -1002,28 +1002,28 @@ The schema for the `:entity` hash for Space is:
 | apps_url              | String /HTTPS_URL_REGEX/                                     |
 | domains_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE Space
- 
+
 Resource URL: `PUT /v2/spaces`
- 
+
 Updates a Space.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                   | notes    | schema                                             |
 | ---------------------- | -------- | -------------------------------------------------- |
 | name                   | optional | String                                             |
@@ -1034,25 +1034,25 @@ Updates a Space.
 | app_guids              | optional | [String]                                           |
 | domain_guids           | optional | [String]                                           |
 | service_instance_guids | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Space is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -1064,33 +1064,33 @@ The schema for the `:entity` hash for Space is:
 | apps_url              | String /HTTPS_URL_REGEX/                                     |
 | domains_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ Space
- 
+
 Resource URL: `READ /v2/spaces/:guid`
- 
+
 Reads a Space.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Space is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -1102,36 +1102,36 @@ The schema for the `:entity` hash for Space is:
 | apps_url              | String /HTTPS_URL_REGEX/                                     |
 | domains_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE Space
- 
+
 Resource URL: `DELETE /v2/spaces/:guid`
- 
+
 Deletes a Space.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## App
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Apps
- 
+
 Resource URL: `GET /v2/apps`
- 
+
 Returns a paginated response of Apps.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -1139,38 +1139,38 @@ Returns a paginated response of Apps.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * name
 * space_guid
 * organization_guid
 * framework_guid
 * runtime_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for App is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -1191,17 +1191,17 @@ The schema for the `:entity` hash for App is:
 | framework_url        | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
 | routes_url           | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE App
- 
+
 Resource URL: `POST /v2/apps`
- 
+
 Creates a App.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | name                 | required | String                                             |
@@ -1218,25 +1218,25 @@ Creates a App.
 | runtime_guid         | required | String                                             |
 | framework_guid       | required | String                                             |
 | route_guids          | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for App is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -1257,28 +1257,28 @@ The schema for the `:entity` hash for App is:
 | framework_url        | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
 | routes_url           | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE App
- 
+
 Resource URL: `PUT /v2/apps`
- 
+
 Updates a App.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | name                  | optional | String                                             |
@@ -1296,25 +1296,25 @@ Updates a App.
 | framework_guid        | optional | String                                             |
 | service_binding_guids | optional | [String]                                           |
 | route_guids           | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for App is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -1335,33 +1335,33 @@ The schema for the `:entity` hash for App is:
 | framework_url        | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
 | routes_url           | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ App
- 
+
 Resource URL: `READ /v2/apps/:guid`
- 
+
 Reads a App.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for App is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -1382,36 +1382,36 @@ The schema for the `:entity` hash for App is:
 | framework_url        | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
 | routes_url           | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE App
- 
+
 Resource URL: `DELETE /v2/apps/:guid`
- 
+
 Deletes a App.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## Runtime
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Runtimes
- 
+
 Resource URL: `GET /v2/runtimes`
- 
+
 Returns a paginated response of Runtimes.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -1419,197 +1419,197 @@ Returns a paginated response of Runtimes.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * name
 * app_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Runtime is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | version              | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE Runtime
- 
+
 Resource URL: `POST /v2/runtimes`
- 
+
 Creates a Runtime.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | name                 | required | String                                             |
 | description          | required | String                                             |
 | app_guids            | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Runtime is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | version              | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE Runtime
- 
+
 Resource URL: `PUT /v2/runtimes`
- 
+
 Updates a Runtime.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | name                 | optional | String                                             |
 | description          | optional | String                                             |
 | app_guids            | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Runtime is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | version              | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ Runtime
- 
+
 Resource URL: `READ /v2/runtimes/:guid`
- 
+
 Reads a Runtime.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Runtime is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | version              | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE Runtime
- 
+
 Resource URL: `DELETE /v2/runtimes/:guid`
- 
+
 Deletes a Runtime.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## Framework
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Frameworks
- 
+
 Resource URL: `GET /v2/frameworks`
- 
+
 Returns a paginated response of Frameworks.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -1617,193 +1617,193 @@ Returns a paginated response of Frameworks.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * name
 * app_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Framework is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE Framework
- 
+
 Resource URL: `POST /v2/frameworks`
- 
+
 Creates a Framework.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | name                 | required | String                                             |
 | description          | required | String                                             |
 | app_guids            | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Framework is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE Framework
- 
+
 Resource URL: `PUT /v2/frameworks`
- 
+
 Updates a Framework.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | name                 | optional | String                                             |
 | description          | optional | String                                             |
 | app_guids            | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Framework is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ Framework
- 
+
 Resource URL: `READ /v2/frameworks/:guid`
- 
+
 Reads a Framework.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Framework is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
 | description          | String                                                       |
 | apps_url             | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE Framework
- 
+
 Resource URL: `DELETE /v2/frameworks/:guid`
- 
+
 Deletes a Framework.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## Service
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST Services
- 
+
 Resource URL: `GET /v2/services`
- 
+
 Returns a paginated response of Services.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -1811,34 +1811,34 @@ Returns a paginated response of Services.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * service_plan_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Service is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
@@ -1851,17 +1851,17 @@ The schema for the `:entity` hash for Service is:
 | timeout              | Integer                                                      |
 | active               | bool                                                         |
 | service_plans_url    | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE Service
- 
+
 Resource URL: `POST /v2/services`
- 
+
 Creates a Service.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | label                | required | String                                             |
@@ -1874,25 +1874,25 @@ Creates a Service.
 | timeout              | optional | Integer                                            |
 | active               | optional | bool                                               |
 | service_plan_guids   | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Service is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
@@ -1905,28 +1905,28 @@ The schema for the `:entity` hash for Service is:
 | timeout              | Integer                                                      |
 | active               | bool                                                         |
 | service_plans_url    | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE Service
- 
+
 Resource URL: `PUT /v2/services`
- 
+
 Updates a Service.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | label                | optional | String                                             |
@@ -1939,25 +1939,25 @@ Updates a Service.
 | timeout              | optional | Integer                                            |
 | active               | optional | bool                                               |
 | service_plan_guids   | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Service is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
@@ -1970,33 +1970,33 @@ The schema for the `:entity` hash for Service is:
 | timeout              | Integer                                                      |
 | active               | bool                                                         |
 | service_plans_url    | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ Service
- 
+
 Resource URL: `READ /v2/services/:guid`
- 
+
 Reads a Service.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for Service is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
@@ -2009,36 +2009,36 @@ The schema for the `:entity` hash for Service is:
 | timeout              | Integer                                                      |
 | active               | bool                                                         |
 | service_plans_url    | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE Service
- 
+
 Resource URL: `DELETE /v2/services/:guid`
- 
+
 Deletes a Service.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## ServicePlan
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST ServicePlans
- 
+
 Resource URL: `GET /v2/service_plans`
- 
+
 Returns a paginated response of ServicePlans.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -2046,35 +2046,35 @@ Returns a paginated response of ServicePlans.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * service_guid
 * service_instance_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServicePlan is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -2083,17 +2083,17 @@ The schema for the `:entity` hash for ServicePlan is:
 | service_guid          | String                                                       |
 | service_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE ServicePlan
- 
+
 Resource URL: `POST /v2/service_plans`
- 
+
 Creates a ServicePlan.
- 
+
 #### Request Format:
- 
+
 | name                   | notes    | schema                                             |
 | ---------------------- | -------- | -------------------------------------------------- |
 | name                   | required | String                                             |
@@ -2101,25 +2101,25 @@ Creates a ServicePlan.
 | description            | required | String                                             |
 | service_guid           | required | String                                             |
 | service_instance_guids | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServicePlan is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -2128,28 +2128,28 @@ The schema for the `:entity` hash for ServicePlan is:
 | service_guid          | String                                                       |
 | service_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE ServicePlan
- 
+
 Resource URL: `PUT /v2/service_plans`
- 
+
 Updates a ServicePlan.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                   | notes    | schema                                             |
 | ---------------------- | -------- | -------------------------------------------------- |
 | name                   | optional | String                                             |
@@ -2157,25 +2157,25 @@ Updates a ServicePlan.
 | description            | optional | String                                             |
 | service_guid           | optional | String                                             |
 | service_instance_guids | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServicePlan is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -2184,33 +2184,33 @@ The schema for the `:entity` hash for ServicePlan is:
 | service_guid          | String                                                       |
 | service_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ ServicePlan
- 
+
 Resource URL: `READ /v2/service_plans/:guid`
- 
+
 Reads a ServicePlan.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServicePlan is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | name                  | String                                                       |
@@ -2219,36 +2219,36 @@ The schema for the `:entity` hash for ServicePlan is:
 | service_guid          | String                                                       |
 | service_url           | String /HTTPS_URL_REGEX/                                     |
 | service_instances_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE ServicePlan
- 
+
 Resource URL: `DELETE /v2/service_plans/:guid`
- 
+
 Deletes a ServicePlan.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## ServiceInstance
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST ServiceInstances
- 
+
 Resource URL: `GET /v2/service_instances`
- 
+
 Returns a paginated response of ServiceInstances.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -2256,37 +2256,37 @@ Returns a paginated response of ServiceInstances.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * name
 * space_guid
 * service_plan_guid
 * service_binding_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceInstance is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -2295,42 +2295,42 @@ The schema for the `:entity` hash for ServiceInstance is:
 | service_plan_guid    | String                                                       |
 | service_plan_url     | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE ServiceInstance
- 
+
 Resource URL: `POST /v2/service_instances`
- 
+
 Creates a ServiceInstance.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | name                  | required | String                                             |
 | space_guid            | required | String                                             |
 | service_plan_guid     | required | String                                             |
 | service_binding_guids | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceInstance is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -2339,53 +2339,53 @@ The schema for the `:entity` hash for ServiceInstance is:
 | service_plan_guid    | String                                                       |
 | service_plan_url     | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE ServiceInstance
- 
+
 Resource URL: `PUT /v2/service_instances`
- 
+
 Updates a ServiceInstance.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | name                  | optional | String                                             |
 | space_guid            | optional | String                                             |
 | service_plan_guid     | optional | String                                             |
 | service_binding_guids | optional | [String]                                           |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceInstance is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -2394,33 +2394,33 @@ The schema for the `:entity` hash for ServiceInstance is:
 | service_plan_guid    | String                                                       |
 | service_plan_url     | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ ServiceInstance
- 
+
 Resource URL: `READ /v2/service_instances/:guid`
- 
+
 Reads a ServiceInstance.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceInstance is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | name                 | String                                                       |
@@ -2429,36 +2429,36 @@ The schema for the `:entity` hash for ServiceInstance is:
 | service_plan_guid    | String                                                       |
 | service_plan_url     | String /HTTPS_URL_REGEX/                                     |
 | service_bindings_url | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE ServiceInstance
- 
+
 Resource URL: `DELETE /v2/service_instances/:guid`
- 
+
 Deletes a ServiceInstance.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## ServiceBinding
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST ServiceBindings
- 
+
 Resource URL: `GET /v2/service_bindings`
- 
+
 Returns a paginated response of ServiceBindings.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -2466,195 +2466,195 @@ Returns a paginated response of ServiceBindings.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
 * app_guid
 * service_instance_guid
- 
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceBinding is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | app_guid              | String                                                       |
 | app_url               | String /HTTPS_URL_REGEX/                                     |
 | service_instance_guid | String                                                       |
 | service_instance_url  | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### CREATE ServiceBinding
- 
+
 Resource URL: `POST /v2/service_bindings`
- 
+
 Creates a ServiceBinding.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | app_guid              | required | String                                             |
 | service_instance_guid | required | String                                             |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceBinding is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | app_guid              | String                                                       |
 | app_url               | String /HTTPS_URL_REGEX/                                     |
 | service_instance_guid | String                                                       |
 | service_instance_url  | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE ServiceBinding
- 
+
 Resource URL: `PUT /v2/service_bindings`
- 
+
 Updates a ServiceBinding.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                  | notes    | schema                                             |
 | --------------------- | -------- | -------------------------------------------------- |
 | app_guid              | optional | String                                             |
 | service_instance_guid | optional | String                                             |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceBinding is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | app_guid              | String                                                       |
 | app_url               | String /HTTPS_URL_REGEX/                                     |
 | service_instance_guid | String                                                       |
 | service_instance_url  | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
+
+
+
 ### READ ServiceBinding
- 
+
 Resource URL: `READ /v2/service_bindings/:guid`
- 
+
 Reads a ServiceBinding.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceBinding is:
- 
+
 | name                  | schema                                                       |
 | --------------------- | ------------------------------------------------------------ |
 | app_guid              | String                                                       |
 | app_url               | String /HTTPS_URL_REGEX/                                     |
 | service_instance_guid | String                                                       |
 | service_instance_url  | String /HTTPS_URL_REGEX/                                     |
- 
- 
- 
- 
+
+
+
+
 ### DELETE ServiceBinding
- 
+
 Resource URL: `DELETE /v2/service_bindings/:guid`
- 
+
 Deletes a ServiceBinding.
- 
+
 #### Response Format:
- 
+
 None
- 
- 
+
+
 ## ServiceAuthToken
- 
- 
+
+
 ## CC Specific API
- 
+
 NOTE: Like the migrations and the models this is being fleshed out and should be reviewed for hierarchy and relationships only.
- 
+
 ### LIST ServiceAuthTokens
- 
+
 Resource URL: `GET /v2/service_auth_tokens`
- 
+
 Returns a paginated response of ServiceAuthTokens.
- 
+
 #### Query Parameters
- 
+
 | Parameter              | Description                                                                      |
 | ---------              | -----------                                                                      |
 | limit                  | Maximum number of results to return.                                             |
@@ -2662,168 +2662,168 @@ Returns a paginated response of ServiceAuthTokens.
 | urls-only              | If 1, only return a list of urls; do not expand metadata or resource attributues |
 | inline-relations-depth | 0 - don't inline any relations and return URLs.  Otherwise, inline to depth N.   |
 | q                      | Search/filter string of the form `<attribute-name>:<value>` |
- 
+
 The `q` query parameter may include the following `attribute-names`:
-* 
- 
+*
+
 See the API Overview for a more detailed description of these parameters.
- 
+
 #### Response Format:
- 
+
 The response is in the standard v2 paginated response format, i.e.:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | total_results        | Integer                                                      |
 | prev_url             | String /HTTPS_URL_REGEX/                                     |
 | next_url             | String /HTTPS_URL_REGEX/                                     |
 | resources            | [{:metadata => Hash,:entity => Hash,}]                       |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceAuthToken is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
 | provider             | String                                                       |
- 
- 
- 
+
+
+
 ### CREATE ServiceAuthToken
- 
+
 Resource URL: `POST /v2/service_auth_tokens`
- 
+
 Creates a ServiceAuthToken.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | label                | required | String                                             |
 | provider             | required | String                                             |
 | token                | required | String                                             |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceAuthToken is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
 | provider             | String                                                       |
- 
- 
- 
- 
+
+
+
+
 ### UPDATE ServiceAuthToken
- 
+
 Resource URL: `PUT /v2/service_auth_tokens`
- 
+
 Updates a ServiceAuthToken.
- 
+
 #### Query Parameters
- 
+
 | Parameter         | Description |
 | ---------         | ----------- |
 | collection-method | See below.  |
- 
+
 `collection-method` may take on the following values:
 * `add` = merge any supplied ids with the relations that already exist.
 * `replace` = any supplied ids replace their corresponding relations.
- 
+
 #### Request Format:
- 
+
 | name                 | notes    | schema                                             |
 | -------------------- | -------- | -------------------------------------------------- |
 | label                | optional | String                                             |
 | provider             | optional | String                                             |
 | token                | optional | String                                             |
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceAuthToken is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
 | provider             | String                                                       |
- 
- 
- 
+
+
+
 ### READ ServiceAuthToken
- 
+
 Resource URL: `READ /v2/service_auth_tokens/:guid`
- 
+
 Reads a ServiceAuthToken.
- 
+
 #### Response Format:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | metadata             | Hash                                                         |
 | entity               | Hash                                                         |
- 
+
 The schema for `:metadata` follows the v2 standard:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | guid                 | String                                                       |
 | url                  | String /HTTPS_URL_REGEX/                                     |
 | created_at           | Date                                                         |
 | updated_at           | Date                                                         |
- 
+
 The schema for the `:entity` hash for ServiceAuthToken is:
- 
+
 | name                 | schema                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | label                | String                                                       |
 | provider             | String                                                       |
- 
- 
- 
- 
+
+
+
+
 ### DELETE ServiceAuthToken
- 
+
 Resource URL: `DELETE /v2/service_auth_tokens/:guid`
- 
+
 Deletes a ServiceAuthToken.
- 
+
 #### Response Format:
- 
+
 None

--- a/source/docs/running/deploying-cf/vsphere/deploy_cf_vsphere.md
+++ b/source/docs/running/deploying-cf/vsphere/deploy_cf_vsphere.md
@@ -2,15 +2,15 @@
 title: Deploying Cloud Foundry with BOSH
 ---
 
-This guide describes the process for deploying Cloud Foundry to a vSphere environment using BOSH. 
+This guide describes the process for deploying Cloud Foundry to a vSphere environment using BOSH.
 
 ## <a id="prerequisites"></a>Prerequisites ##
- 
+
 * BOSH should be deployed. See the steps in the [previous section](deploying_bosh_with_micro_bosh.html).
 
 ## <a id="target"></a>Target New BOSH Director ##
 
-Target the Director of the deployed BOSH using `bosh target` and the IP address of the Director. 
+Target the Director of the deployed BOSH using `bosh target` and the IP address of the Director.
 
 <pre class='terminal'>
 $ bosh target 172.20.134.52
@@ -56,11 +56,11 @@ Director task 1
 
 Update stemcell
 extracting stemcell archive (00:00:06)
-verifying stemcell manifest (00:00:00)                                                         
-checking if this stemcell already exists (00:00:00)                                               
-uploading stemcell bosh-stemcell/0.6.4 to the cloud (00:01:08)                                    
-save stemcell: bosh-stemcell/0.6.4 (sc-a85ab3dc-8d3d-4228-83d0-5be2436a1886) (00:00:00)           
-Done                    5/5 00:01:14                                                                
+verifying stemcell manifest (00:00:00)
+checking if this stemcell already exists (00:00:00)
+uploading stemcell bosh-stemcell/0.6.4 to the cloud (00:01:08)
+save stemcell: bosh-stemcell/0.6.4 (sc-a85ab3dc-8d3d-4228-83d0-5be2436a1886) (00:00:00)
+Done                    5/5 00:01:14
 Task 1 done
 Started		2012-09-26 10:14:26 UTC
 Finished	2012-09-26 10:15:40 UTC
@@ -98,7 +98,7 @@ Deployment set to '/home/user/deployments/cloudfoundry.yml'
 
 ## <a id="deploy"></a>Deploy Cloud Foundry ##
 
-Now deploy Cloud Foundry using `bosh deploy`. This example shows only part of the expected output: 
+Now deploy Cloud Foundry using `bosh deploy`. This example shows only part of the expected output:
 
 <pre class="terminal">
 $ bosh deploy
@@ -127,7 +127,7 @@ $ bosh deploy
 
 Execute the `bosh vms` command to see all the vas deployed.
 
-Output of this command will similar to the listing below. Make sure the "State" of all the jobs is "running".	
+Output of this command will similar to the listing below. Make sure the "State" of all the jobs is "running".
 
 <pre class="terminal">
 $ bosh vms
@@ -137,7 +137,7 @@ Director task 30
 
 
 Task 30 done
-	
+
 +-----------------------------+---------+----------------+---------------+
 | Job/index                   | State   | Resource Pool  | IPs           |
 +-----------------------------+---------+----------------+---------------+
@@ -195,4 +195,4 @@ Task 30 done
 VMs total: 50
 </pre>
 
-The Cloud Foundry deployment should now be ready to use. You can now follow the instructions in the [Using](/docs/using) section of these docs to install the [vmc](/docs/using/managing-apps/vmc) command-line tool and push an application. 
+The Cloud Foundry deployment should now be ready to use. You can now follow the instructions in the [Using](/docs/using) section of these docs to install the [cf](/docs/using/managing-apps/cf) command-line tool and push an application.

--- a/source/docs/running/managing-users/index.md
+++ b/source/docs/running/managing-users/index.md
@@ -2,7 +2,7 @@
 title: Managing Users
 ---
 
-This document is a temporary description for Cloud Foundry operators and dev / ops professionals interested in managing users in a new Cloud Foundry installation. This process is unrefined, and will improve with direct vmc user management in the near future.
+This document is a temporary description for Cloud Foundry operators and dev / ops professionals interested in managing users in a new Cloud Foundry installation. This process is unrefined, and will improve with direct cf user management in the near future.
 
 ## <a id='creating-admin-users'></a> Creating Admin Users ##
 
@@ -17,7 +17,7 @@ $ gem install cf-uaac
 <pre class="terminal">
 $ uaac target uaa.[your-domain].com
 $ uaac token client get admin -s [admin-client-secret]
-</pre class="terminal"> 
+</pre class="terminal">
 
 4. Create an admin user and add them to the admin group:
 <pre class="terminal">
@@ -31,8 +31,8 @@ $ uaac member add cloud_controller.admin [admin-username]
 
 2. Create a new user:
 <pre class="terminal">
-$ vmc login [admin-user-email-address]
+$ cf login [admin-user-email-address]
 ...
-$ vmc create-user [user-email-address]
+$ cf create-user [user-email-address]
 ...
 </pre class="terminal">

--- a/source/docs/running/micro_cloud_foundry/developing_cf.html.md
+++ b/source/docs/running/micro_cloud_foundry/developing_cf.html.md
@@ -34,12 +34,12 @@ To test it:
 $ ping something.[your domain]
 </pre>
 
-## Targetting with vmc
+## Targetting with cf
 
 <pre class="terminal">
-$ vmc target ccng.[your domain]
+$ cf target ccng.[your domain]
 
-$ vmc login micro@vcap.me
+$ cf login micro@vcap.me
 </pre>
 
 The password is "micro".
@@ -47,16 +47,16 @@ The password is "micro".
 Create an org and space:
 
 <pre class="terminal">
-$ vmc create-org org1
+$ cf create-org org1
 
-$ vmc logout
-$ vmc login micro@vcap.me
+$ cf logout
+$ cf login micro@vcap.me
 
-$ vmc create-space space1
-$ vmc target ccng.[your domain] --ask-space
+$ cf create-space space1
+$ cf target ccng.[your domain] --ask-space
 </pre>
 
-Push a test app using [vmc](../../using/managing-apps/vmc) or another Cloud Foundry [application management tool](../../using/managing-apps).
+Push a test app using [cf](../../using/managing-apps/cf) or another Cloud Foundry [application management tool](../../using/managing-apps).
 
 ## Proof of concept development workflow
 

--- a/source/docs/running/micro_cloud_foundry/index.html.md
+++ b/source/docs/running/micro_cloud_foundry/index.html.md
@@ -20,17 +20,17 @@ At this point, MCF will ask for a domain configuration token. You can generate t
 
 ## <a id='using-mcf'></a>Using Micro Cloud Foundry ##
 
-Once this is installed the VM should display the main menu for MCF, note the "Current Configuration" section at the top. With VMC installed, target the MCF installation using the address displayed in the VM console;
+Once this is installed the VM should display the main menu for MCF, note the "Current Configuration" section at the top. With CF installed, target the MCF installation using the address displayed in the VM console;
 
 <pre class="terminal">
-$ vmc target http://api.<mcf domain name>.cloudfoundry.me
-Setting target to http://api.<mcf domain name>.cloudfoundry.me... OK 
-</pre> 
+$ cf target http://api.<mcf domain name>.cloudfoundry.me
+Setting target to http://api.<mcf domain name>.cloudfoundry.me... OK
+</pre>
 
 Now register the admin account, the email address assigned as the admin account should also be displayed in the "Current Configuration" section;
 
 <pre class="terminal">
-$ vmc register <admin email>
+$ cf register <admin email>
 
 Password> ********
 
@@ -232,7 +232,7 @@ request and returning a response to the client. The client browser and
 application interact with the network in exactly the same way they do in
 production, except the cloud is running on the same host.
 
-Development and deployment tools - `vmc` and STS - also work with Micro Cloud
+Development and deployment tools - `cf` and STS - also work with Micro Cloud
 Foundry just as they work with CloudFoundry.com or any local or hosted Cloud
 Foundry instance.
 
@@ -276,7 +276,7 @@ If you use Micro Cloud Foundry in offline mode and still have an active Internet
 
 ### <a id='configuring-for-offline'></a>Configuring Micro Cloud Foundry for Offline Mode ###
 
-You can configure offline mode manually or use the `vmc micro` command. VMC version 0.3.16.beta4 or higher is required to use the `vmc micro` command. See [Using the VMC micro Command](#using-the-vmc-micro-command) for instructions.
+You can configure offline mode manually or use the `cf micro` command. CF version 0.3.16.beta4 or higher is required to use the `cf micro` command. See [Using the CF micro Command](#using-the-cf-micro-command) for instructions.
 
 The remainder of this section describes how to configure offline mode manually.
 
@@ -321,16 +321,16 @@ Follow these steps  whether you configured Micro Cloud Foundry with DHCP or a st
 + Right-click VMware Virtual Ethernet Adapter for VMnet8, and choose Properties.
 + Set the preferred DNS server to 172.16.52.136.
 
-## <a id='vmc-micro-command'></a>Using the VMC Micro Command ##
+## <a id='cf-micro-command'></a>Using the CF Micro Command ##
 
-The `vmc micro` command automates the steps described in the previous section. Review that section to understand how the command changes your configuration.
+The `cf micro` command automates the steps described in the previous section. Review that section to understand how the command changes your configuration.
 
-Install the vmc gem, or upgrade it if needed. You need version 0.3.16.beta4 or greater. See [VMC Installation](/tools/vmc/installing-vmc.html) for instructions.
+Install the cf gem, or upgrade it if needed. You need version 0.3.16.beta4 or greater. See [CF Installation](/tools/cf/installing-cf.html) for instructions.
 
-Here is the syntax for the `vmc micro` command:
+Here is the syntax for the `cf micro` command:
 
 ```bash
-Usage: vmc micro [options] command
+Usage: cf micro [options] command
 
 Options
   --password          VCAP user password
@@ -344,12 +344,12 @@ Commands
   status              Display current status
 ```
 
-To reconfigure and control the virtual machine, vmc needs paths to the .vmx file and the vmrun command. It may find the vmrun command on your path, but the first time you run it you must provide the path to the micro.vmx file using the --vmx option. The paths are saved in the .vmc_micro file in your home directory so you do not have to specify the options again on future runs.
+To reconfigure and control the virtual machine, cf needs paths to the .vmx file and the vmrun command. It may find the vmrun command on your path, but the first time you run it you must provide the path to the micro.vmx file using the --vmx option. The paths are saved in the .cf_micro file in your home directory so you do not have to specify the options again on future runs.
 
-In the following example, the path to the micro.vmx file is specified. vmc discovers that the VM is not running and offers to start it. It reports the status and asks whether to save the password for future runs.
+In the following example, the path to the micro.vmx file is specified. cf discovers that the VM is not running and offers to start it. It reports the status and asks whether to save the password for future runs.
 
 ```bash
-$ vmc micro --vmx /home/mcf/micro.vmx status
+$ cf micro --vmx /home/mcf/micro.vmx status
 Please enter your Micro Cloud Foundry VM password (vcap user)
 Password: ********
 Confirmation: ********
@@ -361,18 +361,18 @@ IP Address: 192.168.255.134
 Do you want to save your password? n
 ```
 
-Execute `vmc micro offline` to work offline.
+Execute `cf micro offline` to work offline.
 
 ```bash
-$ vmc micro offline
+$ cf micro offline
 ```
 
 This puts the VM in offline mode (the same as selecting option 6 from the menu) and sets the DNS on your host to query the VM. For actions that require administrative or root privilege, you may be prompted to authenticate.
 
-Execute `vmc micro online` to work online.
+Execute `cf micro online` to work online.
 
 ```bash
-$ vmc micro online
+$ cf micro online
 ```
 
 This puts the VM in online mode and reverses the DNS configuration change on your host computer. For actions that require administrative or root privilege, you may be prompted to authenticate.
@@ -405,7 +405,7 @@ Another proxy related problem occurs when the VM's network adaptor uses bridged 
 If the DNS entry for your Micro Cloud Foundry VM is not up-to-date, accessing your instance can fail. For example:
 
 ```bash
-$ vmc target api.martin.cloudfoundry.me
+$ cf target api.martin.cloudfoundry.me
 Host is not valid: 'http://api.martin.cloudfoundry.me'
 Would you like see the response [yN]? y
 HTTP exception: Errno::ETIMEDOUT:Operation timed out - connect(2)

--- a/source/docs/using/deploying-apps/custom/index.html.md
+++ b/source/docs/using/deploying-apps/custom/index.html.md
@@ -4,7 +4,7 @@ title: Introduction to Custom Buildpacks
 
 ## <a id='intro'></a>Introduction ##
 
-Buildpacks are a convenient way of packaging framework and/or runtime support for your application. For example, Cloud Foundry doesn't support Django or Python by default. Using a buildpack for Python and Django would allow you to add support for these at the deployment stage. 
+Buildpacks are a convenient way of packaging framework and/or runtime support for your application. For example, Cloud Foundry doesn't support Django or Python by default. Using a buildpack for Python and Django would allow you to add support for these at the deployment stage.
 
 ## <a id='standard-buildpacks'></a>Standard Buildpacks ##
 
@@ -46,7 +46,7 @@ The compile script is responsible for actually building the droplet that will be
 
 The script is run with two arguments, the build directory for the application and the cache directory, which is a location the buildpack can use to store assets during the build process.
 
-During execution of this script all output sent to STDOUT will be relayed via VMC back to the end user. The generally accepted pattern for this is to break out this functionality in to a 'language_pack'. A good example of this can be seen at [https://github.com/cloudfoundry/cloudfoundry-buildpack-java/blob/master/lib/language_pack/java.rb](https://github.com/cloudfoundry/cloudfoundry-buildpack-java/blob/master/lib/language_pack/java.rb)
+During execution of this script all output sent to STDOUT will be relayed via CF back to the end user. The generally accepted pattern for this is to break out this functionality in to a 'language_pack'. A good example of this can be seen at [https://github.com/cloudfoundry/cloudfoundry-buildpack-java/blob/master/lib/language_pack/java.rb](https://github.com/cloudfoundry/cloudfoundry-buildpack-java/blob/master/lib/language_pack/java.rb)
 
 A simple example of this script might look like;
 
@@ -61,7 +61,7 @@ $stdout.sync = true
 build_path = ARGV[0]
 cache_path = ARGV[1]
 
-install_ruby 
+install_ruby
 
 private
 
@@ -77,7 +77,7 @@ end
 
 ### <a id='detect-script'></a>bin/release ###
 
-The release script provides feedback metadata back to Cloud Foundry, it's run with one argument, the build location of the application. 
+The release script provides feedback metadata back to Cloud Foundry, it's run with one argument, the build location of the application.
 
 The expected format for the return data is YAML, for Cloud Foundry it should include two keys: config\_vars and default\_process\_types.
 
@@ -85,7 +85,7 @@ The expected format for the return data is YAML, for Cloud Foundry it should inc
 
 {
   "config_vars" => {}, # environment variables that should be set
-  "default_process_types" => {} # 
+  "default_process_types" => {} #
 }.to_yaml
 
 ~~~
@@ -95,7 +95,7 @@ Return metadata for a Rack application might look like this;
 ~~~ruby
 
 {
-  "config_vars" => { "RACK_ENV" => "production" }, 
+  "config_vars" => { "RACK_ENV" => "production" },
   "default_process_types" => { "web" => "bundle exec rackup config.ru -p $PORT" }
 }.to_yaml
 
@@ -105,10 +105,10 @@ In this example default\_process\_types has a value with the key 'web', this con
 
 ## <a id='deploying-with-custom-buildpacks'></a>Deploying With a Custom Buildpack ##
 
-Once a custom buildpack has been created and pushed to a public git repository, the git URL can be passed via vmc when pushing an application. For example, for a buildpack that has been pushed to github;
+Once a custom buildpack has been created and pushed to a public git repository, the git URL can be passed via cf when pushing an application. For example, for a buildpack that has been pushed to github;
 
 <pre class="terminal">
-$ vmc push my-new-app --buildpack=git://github.com/johndoe/my-buildpack.git
+$ cf push my-new-app --buildpack=git://github.com/johndoe/my-buildpack.git
 </pre>
 
 The application will then be deployed to Cloud Foundry and then the buildpack will be cloned and applied to the application, if the buildpack's bin/detect script returns 0 of course!

--- a/source/docs/using/deploying-apps/javascript/index.html.md
+++ b/source/docs/using/deploying-apps/javascript/index.html.md
@@ -9,7 +9,7 @@ This quickstart guide is for developers who wish to build applications with the 
 ## <a id='prerequisites'></a>Prerequisites ##
 
 * A Cloud Foundry account; you can sign up [here](https://my.cloudfoundry.com/signup)
-* The [vmc](../../managing-apps/vmc) command line tool 
+* The [cf](../../managing-apps/cf) command line tool
 * [Node.js](http://www.nodejs.org) installed using the matching version of Node.js on your Cloud Foundry instance
 * [NPM](http://npmjs.org/) - Node Package Manager, to manage dependencies on your application
 
@@ -53,7 +53,7 @@ Create a file called "package.json" with the following contents:
 }
 ```
 
-This file tells node which libraries are in use (express, in this case) and what versions to use. The engines configuration can also be used to specify which version of node to use, although this is also selected using VMC when deploying the application. For a more detailed explanation of package.json, take a look at the [Node.js documentation](https://npmjs.org/doc/json.html).
+This file tells node which libraries are in use (express, in this case) and what versions to use. The engines configuration can also be used to specify which version of node to use, although this is also selected using CF when deploying the application. For a more detailed explanation of package.json, take a look at the [Node.js documentation](https://npmjs.org/doc/json.html).
 
 
 ## <a id='autoconfiguration'></a>Autoconfiguration ##
@@ -129,27 +129,27 @@ You should see the output `Hello from Cloud Foundry`.
 
 ## <a id='deploy-your-app'></a>Deploying your application ##
 
-With vmc installed, target your desired Cloud Foundry instance and login:
+With cf installed, target your desired Cloud Foundry instance and login:
 
 <pre class="terminal">
-$ vmc target api.cloudfoundry.com
+$ cf target api.cloudfoundry.com
 Setting target to https://api.cloudfoundry.com... OK
 
-$ vmc login
+$ cf login
 </pre>
 
 Deploy the application by using the `push` command. Notice the URL "hello-node.cloudfoundry.com" was taken, so it was changed to "hello-node2.cloudfoundry.com".
 All the other options were left as the default by pushing enter:
 
 <pre class="terminal">
-$ vmc push
+$ cf push
 
 Name> hello-node
 Instances> 1
 
 1: node
 2: other
-Framework> 1   
+Framework> 1
 
 1: node
 2: node06
@@ -205,21 +205,21 @@ $ node -v
 v0.8.2
 </pre>
 
-In this instance you can see the installed version is 0.8.2, so when deploying we would select "node08" for the runtime. To see a list of available runtimes using VMC, use the following command:
+In this instance you can see the installed version is 0.8.2, so when deploying we would select "node08" for the runtime. To see a list of available runtimes using CF, use the following command:
 
 <pre class="terminal">
-$ vmc info --runtimes
+$ cf info --runtimes
 
 Getting runtimes... OK
 
 runtime   description
-java      1.6.0_24   
-java7     1.7.0_04   
-node      0.4.12     
-node06    0.6.8      
-node08    0.8.2      
-ruby18    1.8.7p357  
-ruby19    1.9.2p180  
+java      1.6.0_24
+java7     1.7.0_04
+node      0.4.12
+node06    0.6.8
+node08    0.8.2
+ruby18    1.8.7p357
+ruby19    1.9.2p180
 </pre>
 
 ## <a id='next-steps'></a>Next steps - Binding a service ##

--- a/source/docs/using/deploying-apps/javascript/services.html.md
+++ b/source/docs/using/deploying-apps/javascript/services.html.md
@@ -9,7 +9,7 @@ This guide is for developers who wish to bind a data source to a Node.js applica
 ## <a id='prerequisites'></a>Prerequisites ##
 
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
-* The [VMC](../../managing-apps/) command line tool 
+* The [CF](../../managing-apps/) command line tool
 * [Node.js](http://www.nodejs.org) installed using the matching version of Node.js on your Cloud Foundry instance
 * [NPM](http://npmjs.org/) - Node Package Manager, to manage dependencies on your application
 * A sample application such as the one created in [this](./index.html) tutorial
@@ -124,7 +124,7 @@ var record_visit = function(req, res){
     res.writeHead(200, {'Content-Type': 'text/plain'});
     res.write(rows[0].time_now);
     res.end('\n');
-    
+
     console.log('The solution is: ', );
   });
 
@@ -174,15 +174,15 @@ app.listen(3000);
 
 ### <a id='creating-and-binding'></a> Creating and binding the service ##
 
-To create a service issue the following command with vmc and answer the interactive prompts;
+To create a service issue the following command with cf and answer the interactive prompts;
 
 ~~~bash
-$ vmc create-service
+$ cf create-service
 ~~~
 
-To bind the service to the application, use the following vmc command;
+To bind the service to the application, use the following cf command;
 
 ~~~bash
-$ vmc bind-service --app [application name] --service [service name]
+$ cf bind-service --app [application name] --service [service name]
 ~~~
 

--- a/source/docs/using/deploying-apps/jvm/grails-getting-started.html.md
+++ b/source/docs/using/deploying-apps/jvm/grails-getting-started.html.md
@@ -13,7 +13,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
 * [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) 6 or later
 * [Grails](http://grails.org/Installation) 2.2.0 or later
-* The [vmc](../../managing-apps/vmc) command line tool 
+* The [cf](../../managing-apps/cf) command line tool
 
 ## <a id='sample-project'></a>Creating a Sample Project ##
 
@@ -25,7 +25,7 @@ $ grails create-app hello-world
 $ cd hello-world
 </pre>
 
-Once in the new project directory, test the app to make sure it compiles and starts locally: 
+Once in the new project directory, test the app to make sure it compiles and starts locally:
 
 <pre class="terminal">
 $ grails run-app
@@ -46,10 +46,10 @@ $ grails prod war
 | Done creating WAR target/hello-world-0.1.war
 </pre>
 
-After running this command, a war file sould be created at the location shown in the output. Making sure you are logged in to Cloud Foundry, you can deploy the application using the `vmc` command and specifying the path to the war file using the `--path` option.
+After running this command, a war file sould be created at the location shown in the output. Making sure you are logged in to Cloud Foundry, you can deploy the application using the `cf` command and specifying the path to the war file using the `--path` option.
 
 <pre class="terminal">
-$ vmc push --path=target/hello-world-0.1.war
+$ cf push --path=target/hello-world-0.1.war
 Name> grails-hello-world
 
 Instances> 1

--- a/source/docs/using/deploying-apps/jvm/lift-getting-started.html.md
+++ b/source/docs/using/deploying-apps/jvm/lift-getting-started.html.md
@@ -57,11 +57,11 @@ The application should be available at http://127.0.0.1:8080
 
 ## <a id='intro'></a>Deploying to Cloud Foundry ##
 
-Deploying is as simple as creating a web archive with Maven and pushing the output with VMC;
+Deploying is as simple as creating a web archive with Maven and pushing the output with CF;
 
 <pre class="terminal">
 $ mvn package
-$ vmc push --path=./target/lift_hello_world-1.0.war
+$ cf push --path=./target/lift_hello_world-1.0.war
 Name> lift-hello-world
 
 Instances> 1

--- a/source/docs/using/deploying-apps/jvm/lift-service-bindings.html.md
+++ b/source/docs/using/deploying-apps/jvm/lift-service-bindings.html.md
@@ -13,7 +13,7 @@ First, add the appropriate drivers to the project. Add the MySQL dependency via 
 ~~~xml
 
 <dependencies>
-    
+
   <dependency>
     <groupId>mysql</groupId>
     <artifactId>mysql-connector-java</artifactId>
@@ -27,7 +27,7 @@ First, add the appropriate drivers to the project. Add the MySQL dependency via 
 
 ## <a id='default-properties'></a>Default properties ##
 
-Edit ./src/main/resources/props/default.props and add the configuration for a local instance of MySQL, the configuration below is for a development instance of MySQL where for localhost, the root password is not set. 
+Edit ./src/main/resources/props/default.props and add the configuration for a local instance of MySQL, the configuration below is for a development instance of MySQL where for localhost, the root password is not set.
 
 ~~~
 db.class=com.mysql.jdbc.Driver
@@ -53,7 +53,7 @@ $ mvn package
 This creates a file in the target folder, in this example, the file is called lift\_hello\_world-1.0.war. Deploy it to Cloud Foundry using the path option to point to the archive file, remembering to create a MySQL service for the application;
 
 <pre class="terminal">
-$ vmc push lift-hello-world --path=./target/lift_hello_world-1.0.war
+$ cf push lift-hello-world --path=./target/lift_hello_world-1.0.war
 Instances> 1
 
 1: lift
@@ -126,7 +126,7 @@ To manually configure the database connection using a bound service in Scala, a 
     <name>SpringSource Milestones Proxy</name>
     <url>https://oss.sonatype.org/content/repositories/springsource-milestones</url>
   </repository>
-    
+
   <repository>
     <id>org.springframework.maven.milestone</id>
     <name>Spring Framework Maven Milestone Repository</name>
@@ -194,5 +194,5 @@ $ mvn clean package
 Then push back to Cloud Foundry
 
 <pre class="terminal">
-$ vmc push lift-hello-world --path=./target/lift_hello_world-1.0.war
+$ cf push lift-hello-world --path=./target/lift_hello_world-1.0.war
 </pre>

--- a/source/docs/using/deploying-apps/jvm/play-getting-started.html.md
+++ b/source/docs/using/deploying-apps/jvm/play-getting-started.html.md
@@ -13,7 +13,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
 * [Java JDK](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) 6 or later
 * [Play Framework](http://www.playframework.org/download) 2.0 or later
-* The [vmc](../../managing-apps/vmc) command line tool 
+* The [cf](../../managing-apps/cf) command line tool
 
 ## <a id='sample-project'></a>Creating a Sample Project ##
 
@@ -21,20 +21,20 @@ Start off by creating a new Play application;
 
 <pre class="terminal">
 $ play new hello-world
-       _            _ 
+       _            _
  _ __ | | __ _ _  _| |
 | '_ \| |/ _' | || |_|
 |  __/|_|\____|\__ (_)
-|_|            |__/ 
-             
+|_|            |__/
+
 play! 2.0.2, http://www.playframework.org
 
 The new application will be created in [path]/hello-world
 
-What is the application name? 
+What is the application name?
 > hello-world
 
-Which template do you want to use for this new application? 
+Which template do you want to use for this new application?
 
   1 - Create a simple Scala application
   2 - Create a simple Java application
@@ -66,7 +66,7 @@ $ play redist
 [info] Loading project definition from [path]/hello-world/project
 [info] Set current project to hello-world (in build file:[path]/hello-world/)
 [info] Updating {file:[path]/hello-world/}hello-world...
-[info] Done updating.                                                                  
+[info] Done updating.
 [info] Compiling 6 Scala sources and 1 Java source to [path]/hello-world/target/scala-2.9.1/classes...
 [info] Packaging [path]/hello-world/target/scala-2.9.1/hello-world_2.9.1-1.0-SNAPSHOT.jar ...
 [info] Done packaging.
@@ -76,10 +76,10 @@ Your application is ready in [path]/dist/hello-world-1.0-SNAPSHOT.zip
 [success] Total time: 12 s, completed Feb 4, 2013 2:39:26 PM
 </pre>
 
-Note the penultimate line, specifying the location of distributable zip file. Making sure you are logged in to Cloud Foundry, you can deploy the application using the `vmc` command and specifying the path to the zip file using the `--path` option.
+Note the penultimate line, specifying the location of distributable zip file. Making sure you are logged in to Cloud Foundry, you can deploy the application using the `cf` command and specifying the path to the zip file using the `--path` option.
 
 <pre class="terminal">
-$ vmc push --path=dist/hello-world-1.0-SNAPSHOT.zip
+$ cf push --path=dist/hello-world-1.0-SNAPSHOT.zip
 Name> play-hello-world
 
 Instances> 1

--- a/source/docs/using/deploying-apps/jvm/spring-getting-started.html.md
+++ b/source/docs/using/deploying-apps/jvm/spring-getting-started.html.md
@@ -9,15 +9,15 @@ This guide explains how to deploy a simple Java application using Spring Framewo
 ## <a id='prerequisites'></a>Prerequisites ##
 
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
-* The [vmc](../../managing-apps/vmc) command-line tool 
+* The [cf](../../managing-apps/cf) command-line tool
 * The [Maven](http://maven.apache.org/) build tool
 * The [Git](http://git-scm.com/downloads) command-line tool
 
-There are other options for building, packaging, and managing applications in Cloud Foundry. See the [Managing Apps](../../managing-apps/) section to see the full list of options. 
+There are other options for building, packaging, and managing applications in Cloud Foundry. See the [Managing Apps](../../managing-apps/) section to see the full list of options.
 
 ## <a id='sample-project'></a>Packaging a Sample Project ##
 
-The [Cloud Foundry Samples](https://github.com/cloudfoundry-samples) repository on GitHub contains a simple Spring Framework [sample application](https://github.com/cloudfoundry-samples/springmvc-hibernate-template). The following steps will show how to download, build, and package this sample application for deploying to Cloud Foundry. 
+The [Cloud Foundry Samples](https://github.com/cloudfoundry-samples) repository on GitHub contains a simple Spring Framework [sample application](https://github.com/cloudfoundry-samples/springmvc-hibernate-template). The following steps will show how to download, build, and package this sample application for deploying to Cloud Foundry.
 
 First, download a copy of the code for the application by cloning the GitHub repository using the `git` command-line tool:
 
@@ -32,17 +32,17 @@ A Spring application is typically packaged as a `.war` file for deployment to Cl
 $ mvn package
 </pre>
 
-After this step, there should be a `springmvc31-1.0.0.war` file in the `target` directory. 
+After this step, there should be a `springmvc31-1.0.0.war` file in the `target` directory.
 
 ## <a id='deploying'></a>Deploying Your Application ##
 
-With vmc, target your desired Cloud Foundry instance and login:
+With cf, target your desired Cloud Foundry instance and login:
 
 <pre class="terminal">
-$ vmc target api.cloudfoundry.com
+$ cf target api.cloudfoundry.com
 Setting target to https://api.cloudfoundry.com... OK
 
-$ vmc login
+$ cf login
 target: https://api.cloudfoundry.com
 
 Email> *********
@@ -51,10 +51,10 @@ Password> *******
 Authenticating... OK
 </pre>
 
-Then use vmc to push the application, providing answers to the prompts as shown below (note that you must use a name other than "springmvc31" in the `vmc push` command, since that application name has already been used on cloudfoundry.com):
+Then use cf to push the application, providing answers to the prompts as shown below (note that you must use a name other than "springmvc31" in the `cf push` command, since that application name has already been used on cloudfoundry.com):
 
 <pre class="terminal">
-$ vmc push springmvc31 --path target/springmvc31-1.0.0.war
+$ cf push springmvc31 --path target/springmvc31-1.0.0.war
 Instances> 1
 
 1: spring
@@ -93,7 +93,7 @@ Create services for application?> y
 8: redis 2.2
 What kind?> 4
 
-Name?> spring-postgres 
+Name?> spring-postgres
 
 Creating service spring-postgres... OK
 Binding spring-postgres to springmvc31... OK

--- a/source/docs/using/deploying-apps/ruby/migrating-to-buildpacks.html.md
+++ b/source/docs/using/deploying-apps/ruby/migrating-to-buildpacks.html.md
@@ -48,7 +48,7 @@ like below will break everything and should be removed:
 
 ~~~ruby
 # CloudFoundry only puts credentials in database.yml's production section
-if ENV.has_key?("VMC_APP_VERSION")
+if ENV.has_key?("CF_APP_VERSION")
   ActiveRecord::Base.establish_connection("production")
 end
 ~~~

--- a/source/docs/using/deploying-apps/ruby/rack-getting-started.html.md
+++ b/source/docs/using/deploying-apps/ruby/rack-getting-started.html.md
@@ -13,7 +13,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
 * [Ruby](http://www.ruby-lang.org/en/)
 * [Bundler](http://gembundler.com/)
-* The [VMC](../../managing-apps/) command line tool 
+* The [CF](../../managing-apps/) command line tool
 
 ## <a id='sample-project'></a>Creating a Sample Project ##
 
@@ -57,10 +57,10 @@ View your application at [http://localhost:9292](http://localhost:9292)
 
 ## <a id='deploying'></a>Deploying Your Application ##
 
-Push the application with VMC;
+Push the application with CF;
 
 <pre class="terminal">
-$ vmc push
+$ cf push
 
 Name> rack-test
 

--- a/source/docs/using/deploying-apps/ruby/rails-getting-started.html.md
+++ b/source/docs/using/deploying-apps/ruby/rails-getting-started.html.md
@@ -14,7 +14,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * [Ruby](http://www.ruby-lang.org/en/)
 * [Rails](http://rubyonrails.org/)
 * [Bundler](http://gembundler.com/)
-* The [VMC](../../managing-apps/) command line tool 
+* The [CF](../../managing-apps/) command line tool
 * A basic understanding of how to create and run Rails applications
 
 ## <a id='sample-project'></a>Creating a Sample Project ##
@@ -40,7 +40,7 @@ $ rm public/index.html
 $ vi config/routes.rb
 </pre>
 
-Also, change the default root for the application to point to the new controller, so it looks like 
+Also, change the default root for the application to point to the new controller, so it looks like
 
 ~~~ruby
 SampleRails::Application.routes.draw do
@@ -64,7 +64,7 @@ To precompile asssets before deployment use the following command;
 rake assets:precompile
 </pre>
 
-Doing this before deployment ensures that staging the application will take less time as the precomplilation task will not need to take place on Cloud Foundry. 
+Doing this before deployment ensures that staging the application will take less time as the precomplilation task will not need to take place on Cloud Foundry.
 
 One potential problem can occur during application initialization. The precompile rake task will run a complete re-initialization of the Rails application. This might trigger some of the initialization procedures and require service connections and environment checks that are unavailable during staging. You can turn this off by adding a configuration option in application.rb:
 
@@ -80,19 +80,19 @@ Rails.application.config.assets.compile = true
 
 ## <a id='deploying'></a>Deploying Your Application ##
 
-With VMC installed, target your desired Cloud Foundry instance and login
+With CF installed, target your desired Cloud Foundry instance and login
 
 <pre class="terminal">
-$ vmc target api.cloudfoundry.com
+$ cf target api.cloudfoundry.com
 Setting target to https://api.cloudfoundry.com... OK
 
-$ vmc login
+$ cf login
 </pre>
 
 Deploy the application by using the "push" command and follow the prompts;
 
 <pre class="terminal">
-$ vmc push rails-3-test
+$ cf push rails-3-test
 Instances> 1
 
 1: rails3
@@ -134,7 +134,7 @@ Starting rails-3-test... OK
 Checking rails-3-test... OK
 </pre>
 
-At this point, the application should be available to view at the URL specified when performing the push. 
+At this point, the application should be available to view at the URL specified when performing the push.
 
 ## <a id='next-steps'></a>Next steps - Binding a service ##
 

--- a/source/docs/using/deploying-apps/ruby/rails-running-worker-tasks.html.md
+++ b/source/docs/using/deploying-apps/ruby/rails-running-worker-tasks.html.md
@@ -71,12 +71,12 @@ $ touch app/workers/thing_worker.rb
 
 ~~~ruby
 class ThingWorker
-  
+
   include Sidekiq::Worker
 
   def perform(count)
-    
-    count.times do 
+
+    count.times do
 
       thing_uuid = UUIDTools::UUID.random_create.to_s
       Thing.create :title => "New Thing (#{thing_uuid})", :description => "This is the description for thing #{thing_uuid}"
@@ -87,7 +87,7 @@ class ThingWorker
 end
 ~~~
 
-This worker will create n number of things, where n is the value passed to the worker. 
+This worker will create n number of things, where n is the value passed to the worker.
 
 Create a controller for 'things';
 
@@ -123,13 +123,13 @@ $ touch app/views/things/index.html.erb
 
 ## <a id='deploy'></a>Deploying once, deploying twice... ##
 
-This application needs to be deployed twice for it to work, once as a Rails web application and once as a standalone Ruby application. The easiest way to do this is to keep separate VMC manifests for each application type;
+This application needs to be deployed twice for it to work, once as a Rails web application and once as a standalone Ruby application. The easiest way to do this is to keep separate CF manifests for each application type;
 
 Web Manifest (save this as web-manifest.yml);
 
 ~~~yaml
---- 
-applications: 
+---
+applications:
 - name: sidekiq
   framework: rails3
   runtime: ruby19
@@ -137,12 +137,12 @@ applications:
   instances: 1
   url: sidekiq.${target-base}
   path: .
-  services: 
-    sidekiq-mysql: 
+  services:
+    sidekiq-mysql:
       vendor: mysql
       version: "5.1"
       tier: free
-    sidekiq-redis: 
+    sidekiq-redis:
       vendor: redis
       version: "2.6"
       tier: free
@@ -151,36 +151,36 @@ applications:
 Worker Manifest (save this as worker-manifest.yml);
 
 ~~~yaml
---- 
-applications: 
+---
+applications:
 - name: sidekiq-worker
   framework: standalone
   runtime: ruby19
   memory: 256M
   instances: 1
-  url: 
+  url:
   path: .
   command: bundle exec sidekiq
-  services: 
-    sidekiq-redis: 
+  services:
+    sidekiq-redis:
       vendor: redis
       version: "2.6"
       tier: free
-    sidekiq-mysql: 
+    sidekiq-mysql:
       vendor: mysql
       version: "5.1"
       tier: free
 ~~~
 
-The url 'sidekiq.cloudfoundry.com' will probably be taken, change it in web-manifest.yml first. 
+The url 'sidekiq.cloudfoundry.com' will probably be taken, change it in web-manifest.yml first.
 Push the application with both manifest files;
 
 <pre class="terminal">
-$ vmc push -m web-manifest.yml
-$ vmc push -m worker-manifest.yml
+$ cf push -m web-manifest.yml
+$ cf push -m worker-manifest.yml
 </pre>
 
-VMC will likely ask for a URL for the worker application, select option 2 - "none".
+CF will likely ask for a URL for the worker application, select option 2 - "none".
 
 ## <a id='test'></a>Testing the application ##
 
@@ -195,6 +195,6 @@ The nice thing about this approach is it makes scaling your Sidekiq workers triv
 Change the number of workers to two;
 
 <pre class="terminal">
-$ vmc scale sidekiq-worker --instances 2
+$ cf scale sidekiq-worker --instances 2
 </pre>
 

--- a/source/docs/using/deploying-apps/ruby/rails-service-bindings.html.md
+++ b/source/docs/using/deploying-apps/ruby/rails-service-bindings.html.md
@@ -14,7 +14,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * [Ruby](http://www.ruby-lang.org/en/)
 * [Rails](http://rubyonrails.org/)
 * [Bundler](http://gembundler.com/)
-* The [VMC](../../managing-apps/) command line tool 
+* The [CF](../../managing-apps/) command line tool
 * A sample application such as the one created in [this](./rails-getting-started.html) tutorial
 
 ## <a id='gemfile'></a>Configuring your Gemfile ##
@@ -58,19 +58,19 @@ production:
 
 For MongoDB there are a few different gems you can use, however if you are looking for an ActiveRecord-like ORM, best use [Mongo Mapper](http://mongomapper.com/). This requires a few changes to the application itself, all the changes are explained in detail on the "[Rails 3 - Getting Started]" page of the Mongo DB website.
 
-Both 
+Both
 
 ## <a id='creating-and-binding'></a>Creating and binding the service ##
 
-To create a service issue the following command with vmc and answer the interactive prompts;
+To create a service issue the following command with cf and answer the interactive prompts;
 
 <pre class="terminal">
-$ vmc create-service
+$ cf create-service
 </pre>
 
-To bind the service to the application, use the following vmc command;
+To bind the service to the application, use the following cf command;
 
 <pre class="terminal">
-$ vmc bind-service --app [application name] --service [service name]
+$ cf bind-service --app [application name] --service [service name]
 </pre>
 

--- a/source/docs/using/deploying-apps/ruby/rails-using-the-console.html.md
+++ b/source/docs/using/deploying-apps/ruby/rails-using-the-console.html.md
@@ -4,14 +4,14 @@ title: Rails 3, Using the Console
 
 ## <a id='intro'></a>Introduction ##
 
-From debugging issues on a production application to managing data, the Rails console is an invaluable tool. VMC makes it very simple to get a connection to a Rails console up and running.
+From debugging issues on a production application to managing data, the Rails console is an invaluable tool. CF makes it very simple to get a connection to a Rails console up and running.
 
-## <a id='install'></a>Installing the console plugin for VMC ##
+## <a id='install'></a>Installing the console plugin for CF ##
 
-First step, make sure you have the 'tunnel-vmc-plugin' gem installed;
+First step, make sure you have the 'tunnel-cf-plugin' gem installed;
 
 <pre class="terminal">
-$ gem install tunnel-vmc-plugin
+$ gem install tunnel-cf-plugin
 </pre>
 
 ## <a id='invoke'></a>Invoking the console ##
@@ -19,9 +19,9 @@ $ gem install tunnel-vmc-plugin
 Next, invoke the console with the following command;
 
 <pre class="terminal">
-$ vmc console [application name]
+$ cf console [application name]
 Opening console on port 10000... OK
-irb():001:0> 
+irb():001:0>
 </pre>
 
 The familiar IRB-style console should open with a live connection to the Rails application.

--- a/source/docs/using/deploying-apps/ruby/ruby-service-bindings.html.md
+++ b/source/docs/using/deploying-apps/ruby/ruby-service-bindings.html.md
@@ -8,21 +8,21 @@ This guide is for developers who wish to bind a data source to a Ruby applicatio
 
 ## <a id='creating-and-binding'></a>Creating and binding the service ##
 
-To create a service issue the following command with vmc and answer the interactive prompts;
+To create a service issue the following command with cf and answer the interactive prompts;
 
 <pre class="terminal">
-$ vmc create-service
+$ cf create-service
 </pre>
 
-To bind the service to the application, use the following vmc command;
+To bind the service to the application, use the following cf command;
 
 <pre class="terminal">
-$ vmc bind-service --app [application name] --service [service name]
+$ cf bind-service --app [application name] --service [service name]
 </pre>
 
 ## <a id='autoconfig'></a>Auto Configuration ##
 
-Cloud Foundry provides auto configuration for Redis, Mongo DB, MySQL, PostgreSQL and RabbitMQ. This means that Cloud Foundry will automatically override connection configuration for any services bound to the application. 
+Cloud Foundry provides auto configuration for Redis, Mongo DB, MySQL, PostgreSQL and RabbitMQ. This means that Cloud Foundry will automatically override connection configuration for any services bound to the application.
 This is limited to one instance of a service of each type and is only really appropriate for development use, it's generally better practice, in production to use the connection details provided by the VCAP_SERVICES environment variables (covered later).
 
 To enable auto configuration, include the following line in your Gemfile
@@ -31,9 +31,9 @@ To enable auto configuration, include the following line in your Gemfile
 gem 'cf-autoconfig', :require => 'cfautoconfig'
 ~~~
 
-Also add the correct gem for your service and make sure the appropriate service is bound to the application. 
+Also add the correct gem for your service and make sure the appropriate service is bound to the application.
 
-Assuming you are using Bundler to manage gem dependencies and depending on which service you plan to bind to your application, you need to make sure the correct gem is included in the project and the bundle has been updated. 
+Assuming you are using Bundler to manage gem dependencies and depending on which service you plan to bind to your application, you need to make sure the correct gem is included in the project and the bundle has been updated.
 
 <pre>
 Service Type      Gem
@@ -68,7 +68,7 @@ PostgreSQL
 conn = PG.connect( dbname: 'localdbname' )
 ~~~
 
-Mongo 
+Mongo
 
 ~~~ruby
 client = MongoClient.new('localhost', 27017)
@@ -124,7 +124,7 @@ MySQL - ENV["mysql-5.1"][0]
 RabbitMQ - ENV["rabbitmq-2.4"][0]
 
 ~~~json
-{ 
+{
   "rabbitmq-2.4": [
     {
       "name": "rabbitmq-baa85",

--- a/source/docs/using/deploying-apps/ruby/sinatra-getting-started.html.md
+++ b/source/docs/using/deploying-apps/ruby/sinatra-getting-started.html.md
@@ -13,7 +13,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
 * [Ruby](http://www.ruby-lang.org/en/)
 * [Bundler](http://gembundler.com/)
-* The [VMC](../../managing-apps/) command line tool 
+* The [CF](../../managing-apps/) command line tool
 
 ## <a id='sample-project'></a>Creating a Sample Project ##
 
@@ -72,10 +72,10 @@ View your application at [http://localhost:9292](http://localhost:9292)
 
 ## <a id='deploying'></a>Deploying Your Application ##
 
-Push the application with VMC;
+Push the application with CF;
 
 <pre class="terminal">
-$ vmc push
+$ cf push
 
 Name> sinatra-hello-world
 

--- a/source/docs/using/deploying-apps/ruby/standalone-app-getting-started.html.md
+++ b/source/docs/using/deploying-apps/ruby/standalone-app-getting-started.html.md
@@ -13,7 +13,7 @@ To complete this quickstart guide, you need to fulfill the following prerequisit
 * A Cloud Foundry account, you can sign up [here](https://my.cloudfoundry.com/signup)
 * [Ruby](http://www.ruby-lang.org/en/)
 * [Bundler](http://gembundler.com/)
-* The [VMC](../../managing-apps/) command line tool 
+* The [CF](../../managing-apps/) command line tool
 
 ## <a id='sample-project'></a>Creating a Sample Project ##
 
@@ -43,7 +43,7 @@ require 'bundler/setup'
 require 'clockwork'
 
 class Job
-  
+
   def do_job(frequency)
     puts "Doing job for #{frequency}"
   end
@@ -66,7 +66,7 @@ every(1.week, :week)
 Clockwork::run
 ~~~
 
-As shown in the code above the, every hour, day and week the a job class is created and the method 'do_job' is called. 
+As shown in the code above the, every hour, day and week the a job class is created and the method 'do_job' is called.
 
 Install the required Clockwork gem using bundler
 
@@ -90,12 +90,12 @@ Doing job for week
 
 ## <a id='deploying'></a>Deploying Your Application ##
 
-Push the application with VMC;
+Push the application with CF;
 
 <pre class="terminal">
-$ vmc push
+$ cf push
 
-Name> scheduler  
+Name> scheduler
 
 Instances> 1
 
@@ -133,7 +133,7 @@ Creating scheduler... OK
 
 1: scheduler.cloudfoundry.com
 2: none
-URL> 2                         
+URL> 2
 
 
 Create services for application?> n
@@ -152,7 +152,7 @@ As shown above when asked for the application type, select 'standalone' and then
 Once this is deployed, we can check it is running correctly by viewing the stdout log;
 
 <pre class="terminal">
-$ vmc file scheduler logs/stdout.log
+$ cf file scheduler logs/stdout.log
 Getting file contents... OK
 
 No Redis service bound to app.  Skipping auto-reconfiguration.

--- a/source/docs/using/index.html.md
+++ b/source/docs/using/index.html.md
@@ -4,7 +4,7 @@ title: Using Cloud Foundry
 
 Cloud Foundry is an open platform as a service, providing a choice of developer frameworks and application services. Cloud Foundry makes it faster and easier to build, test, deploy and scale applications.
 
-This section of the Cloud Foundry documentation is for developers pushing applications to Cloud Foundry. If you are interested in deploying and managing your own Cloud Foundry platform, refer to the [Running Cloud Foundry](/docs/running/index.html) section of the documentation. 
+This section of the Cloud Foundry documentation is for developers pushing applications to Cloud Foundry. If you are interested in deploying and managing your own Cloud Foundry platform, refer to the [Running Cloud Foundry](/docs/running/index.html) section of the documentation.
 
 * [Application Architecture Considerations](app-arch/index.html)
 
@@ -20,12 +20,12 @@ This section of the Cloud Foundry documentation is for developers pushing applic
 
 * [Managing Apps](managing-apps/index.html)
 
-  * [vmc](managing-apps/vmc/index.html)
+  * [cf](managing-apps/cf/index.html)
 
   * [Organizations & Spaces](managing-apps/orgs-and-spaces.html)
-  
+
   * [Spring Tool Suite](managing-apps/sts/index.html)
- 
+
   * [Build tools](managing-apps/build-tools/index.html)
 
   * [API and Libraries](managing-apps/libs/index.html)

--- a/source/docs/using/managing-apps/build-tools/gradle.html.md
+++ b/source/docs/using/managing-apps/build-tools/gradle.html.md
@@ -83,4 +83,4 @@ BUILD SUCCESSFUL
 Total time: 2.543 secs
 </pre>
 
-From this point it should be possible to carry out most tasks available as part of vmc from within Gradle. For more information on configuration options within Gradle, take a look at the gradle-cf-plugin project on Github - https://github.com/melix/gradle-cf-plugin
+From this point it should be possible to carry out most tasks available as part of cf from within Gradle. For more information on configuration options within Gradle, take a look at the gradle-cf-plugin project on Github - https://github.com/melix/gradle-cf-plugin

--- a/source/docs/using/managing-apps/cf/index.html.md
+++ b/source/docs/using/managing-apps/cf/index.html.md
@@ -1,51 +1,51 @@
 ---
-title: VMC (VMware Cloud) console interface
+title: CF (VMware Cloud) console interface
 ---
 
 ## <a id='intro'></a>Introduction ##
 
-VMC is Cloud Foundry's console-based interface. Using this tool you can deploy and manage applications running on most Cloud Foundry based environments including CloudFoundry.com. 
+CF is Cloud Foundry's console-based interface. Using this tool you can deploy and manage applications running on most Cloud Foundry based environments including CloudFoundry.com.
 
-## <a id='installing'></a>Installing VMC ##
+## <a id='installing'></a>Installing CF ##
 
-To use VMC you will need to install Ruby and Rubygems, if you are unsure how to do this then see [http://www.ruby-lang.org/en/downloads/](http://www.ruby-lang.org/en/downloads/) for instructions on how to install Ruby on your operating system.
+To use CF you will need to install Ruby and Rubygems, if you are unsure how to do this then see [http://www.ruby-lang.org/en/downloads/](http://www.ruby-lang.org/en/downloads/) for instructions on how to install Ruby on your operating system.
 
 For details on how to install the latest version of Rubygems, take a look at the download and install instructions at [http://www.rubygems.org](http://www.rubygems.org)
 
 ## <a id='commands'></a>Commands ##
 
-Commands in VMC are broken up in to managing various concerns on Cloud Foundry; applications, services, organisations, spaces, domains etc. Issue a command by running 'VMC' in the console immediately followed by a command name, for example;
+Commands in CF are broken up in to managing various concerns on Cloud Foundry; applications, services, organisations, spaces, domains etc. Issue a command by running 'CF' in the console immediately followed by a command name, for example;
 
 <pre class="terminal">
-$ vmc push my-new-app
+$ cf push my-new-app
 </pre>
 
 ### Applications ###
 
 #### Management commands
 
-These are the primary application-centric commands for VMC;
+These are the primary application-centric commands for CF;
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc push [application name]</pre>
+  <pre class="terminal">$ cf push [application name]</pre>
   <div>Deploy a new application, or, if the application already exists, upload any changes made since the last push.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
   <pre class="terminal">$ delete [list of application names]</pre>
-  <div>Delete a single or a list of applications. VMC will ask for confirmation to delete the specified applications and whether or not any services orphaned by removing the application should be removed as well.</div>
+  <div>Delete a single or a list of applications. CF will ask for confirmation to delete the specified applications and whether or not any services orphaned by removing the application should be removed as well.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc rename [application name] [new application name]</pre>
+  <pre class="terminal">$ cf rename [application name] [new application name]</pre>
   <div>Rename an application, changing the existing name to the specified new value.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc restart [list of application names]</pre>
+  <pre class="terminal">$ cf restart [list of application names]</pre>
   <div>Stop one or more applications and start them again.</div>
   <div class="break"></div>
 </div>
@@ -128,7 +128,7 @@ When trying to resolve issues with a production application, access to the file 
 
 <div class="command-doc">
   <pre class="terminal">$ logs [application name]</pre>
-  <div>Display the staging, stdout and stderr log for an application. Application specific logs can be viewed using the 'vmc file' command.</div>
+  <div>Display the staging, stdout and stderr log for an application. Application specific logs can be viewed using the 'cf file' command.</div>
   <div class="break"></div>
 </div>
 
@@ -160,11 +160,11 @@ When trying to resolve issues with a production application, access to the file 
   Set the number of instances for a application and the amount of memory assigned to each instance.
   To change the number of instances use the --instances flag, this can be used with either and absolute value or a +/- modifier. For example, if an application, called my_app, has one instance and we wish to increase this to three, this could be achieved with either of the following commands;
 
-  'vmc scale my_app --instances +2' or 'vmc my_app scale --instances 3'
+  'cf scale my_app --instances +2' or 'cf my_app scale --instances 3'
 
   To set the assigned memory use the --mem switch, to scale to 512Mb per instance we would use the command;
 
-  'vmc scale my_app --mem 512M'
+  'cf scale my_app --mem 512M'
 </div>
 <br />
 <pre class="terminal">$ stats [application name]</pre>
@@ -174,13 +174,13 @@ When trying to resolve issues with a production application, access to the file 
 ### Services ###
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc service [instance name]</pre>
+  <pre class="terminal">$ cf service [instance name]</pre>
   <div>Show service instance information.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc services</pre>
+  <pre class="terminal">$ cf services</pre>
   <div>Lists all provisioned services, showing service type and version.</div>
   <div class="break"></div>
 </div>
@@ -189,7 +189,7 @@ When trying to resolve issues with a production application, access to the file 
 
 <div class="command-doc">
   <pre class="terminal">$ create-service [service type] [instance name]</pre>
-  <div>Create a new service instance. All parameters are optional, you can just choose to follow VMCs interactive prompts to select the type of the service and the instance name.</div>
+  <div>Create a new service instance. All parameters are optional, you can just choose to follow CFs interactive prompts to select the type of the service and the instance name.</div>
   <div class="break"></div>
 </div>
 
@@ -226,31 +226,31 @@ When trying to resolve issues with a production application, access to the file 
 ### Organisations ###
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc create-org [organisation name]</pre>
+  <pre class="terminal">$ cf create-org [organisation name]</pre>
   <div>Create an organization</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc create-org [organisation name]</pre>
+  <pre class="terminal">$ cf create-org [organisation name]</pre>
   <div>Create an organization</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc delete-org [organisation name]</pre>
+  <pre class="terminal">$ cf delete-org [organisation name]</pre>
   <div>Delete an organization</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc org [organisation name]</pre>
+  <pre class="terminal">$ cf org [organisation name]</pre>
   <div>Show organization information</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc orgs</pre>
+  <pre class="terminal">$ cf orgs</pre>
   <div>List available organizations</div>
   <div class="break"></div>
 </div>
@@ -351,35 +351,35 @@ Routes are the actual mappings between a domain and an application. An example w
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc routes</pre>
+  <pre class="terminal">$ cf routes</pre>
   <div>List routes in a space.</div>
   <div class="break"></div>
 </div>
 
 ## <a id='plug-ins'></a>Plug-ins ##
 
-VMC allows the use of plug-ins to extend it's own functionality. The four main plug-ins maintained from the [Cloud Foundry vmc-plugins repository](http://github.com/cloudfoundry/vmc-plugins) are admin, console, mcf and tunnel.
+CF allows the use of plug-ins to extend it's own functionality. The four main plug-ins maintained from the [Cloud Foundry cf-plugins repository](http://github.com/cloudfoundry/cf-plugins) are admin, console, mcf and tunnel.
 
 ### Admin ###
- 
+
 This plugin allows the management of users on a Cloud Foundry instance, this requires an admin account.
 
 The following commands are made available by the plug-in;
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc create-user [email]</pre>
+  <pre class="terminal">$ cf create-user [email]</pre>
   <div>Create a new user account.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc delete-user [email]</pre>
+  <pre class="terminal">$ cf delete-user [email]</pre>
   <div>Delete a user account.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc passwd [email]</pre>
+  <pre class="terminal">$ cf passwd [email]</pre>
   <div>Set a user's password.</div>
   <div class="break"></div>
 </div>
@@ -391,29 +391,29 @@ The console plug-in allows Rails developers to connect to a Rails console runnin
 
 ### MCF ###
 
-This plugin can be used to switch a Micro Cloud Foundry VM between online and offline mode. Install it with Ruby Gems, the gem name is mcf-vmc-plugin.
+This plugin can be used to switch a Micro Cloud Foundry VM between online and offline mode. Install it with Ruby Gems, the gem name is mcf-cf-plugin.
 
 The following commands are made available by the plug-in;
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc micro-status [vmx path] [password]</pre>
+  <pre class="terminal">$ cf micro-status [vmx path] [password]</pre>
   <div>Display Micro Cloud Foundry VM status for a particular VMX path.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc micro-offline [vmx path] [password]</pre>
+  <pre class="terminal">$ cf micro-offline [vmx path] [password]</pre>
   <div>Switch a Micro Cloud Foundry instance to offline mode.</div>
   <div class="break"></div>
 </div>
 
 <div class="command-doc">
-  <pre class="terminal">$ vmc micro-online [vmx path] [password]</pre>
+  <pre class="terminal">$ cf micro-online [vmx path] [password]</pre>
   <div>Switch a Micro Cloud Foundry instance to online mode.</div>
   <div class="break"></div>
 </div>
 
-For a more detailed explanation of this plugin see the [micro cloud foundry vmc plugin](/docs/running/micro-cloud-foundry/vmc_plugin.html) page of the Micro Cloud Foundry section.
+For a more detailed explanation of this plugin see the [micro cloud foundry cf plugin](/docs/running/micro-cloud-foundry/cf_plugin.html) page of the Micro Cloud Foundry section.
 
 ### Tunnel ###
 

--- a/source/docs/using/managing-apps/ide/index.html.md
+++ b/source/docs/using/managing-apps/ide/index.html.md
@@ -2,7 +2,7 @@
 title: IDE Integration
 ---
 
-Support for Cloud Foundry integration is available in several IDEs, for users not so keen on using VMC, it may be worth looking at using one of the following IDEs.
+Support for Cloud Foundry integration is available in several IDEs, for users not so keen on using CF, it may be worth looking at using one of the following IDEs.
 
 
 * [Spring Tool Suite and Groovy/Grails Tool Suite](./sts.html)

--- a/source/docs/using/managing-apps/index.html.md
+++ b/source/docs/using/managing-apps/index.html.md
@@ -2,9 +2,9 @@
 title: Managing Applications
 ---
 
-This section covers in detail the tools that can be used to manage applications and services running on Cloud Foundry. 
+This section covers in detail the tools that can be used to manage applications and services running on Cloud Foundry.
 
-* [vmc](vmc/index.html)
+* [cf](cf/index.html)
 
 * [Organizations & Spaces](orgs-and-spaces.html)
 

--- a/source/docs/using/managing-apps/libs/index.html.md
+++ b/source/docs/using/managing-apps/libs/index.html.md
@@ -2,16 +2,16 @@
 title: API and Libraries
 ---
 
-Cloud Foundry's Cloud Controller component implements a REST API for querying and managing a Cloud Foundry environment. The full REST API is documented in the [reference section](/docs/reference/cc-api.html) of this site. 
+Cloud Foundry's Cloud Controller component implements a REST API for querying and managing a Cloud Foundry environment. The full REST API is documented in the [reference section](/docs/reference/cc-api.html) of this site.
 
-There are libraries available that provide language-specific bindings to the Cloud Controller REST API. 
+There are libraries available that provide language-specific bindings to the Cloud Controller REST API.
 
 * Java client library (vcap-java-client)
 
 * Ruby gem (cfoundry)
 
-  CFoundry is the same library that is used to provide vmc with it's interface to a Cloud Foundry instance. See the [RubyDoc](http://rubydoc.info/gems/cfoundry) page for a full API breakdown. For an introduction to using this library to manage applications on Cloud Foundry see [Using the CFoundry Ruby Gem to manage applications](./ruby-cfoundry.html)
+  CFoundry is the same library that is used to provide cf with it's interface to a Cloud Foundry instance. See the [RubyDoc](http://rubydoc.info/gems/cfoundry) page for a full API breakdown. For an introduction to using this library to manage applications on Cloud Foundry see [Using the CFoundry Ruby Gem to manage applications](./ruby-cfoundry.html)
 
-* Node.js module (cf-runtime) 
+* Node.js module (cf-runtime)
     * see http://blog.cloudfoundry.com/2012/08/21/new-runtime-module-for-node-js-applications/
 

--- a/source/docs/using/managing-apps/libs/ruby-cfoundry-legacy.html.md
+++ b/source/docs/using/managing-apps/libs/ruby-cfoundry-legacy.html.md
@@ -38,9 +38,9 @@ client.services.collect { |x| x.description }
 
 ~~~
 
-## <a id='persist-authentication'></a>Persisting Authentication (Using vmc tokens) ##
+## <a id='persist-authentication'></a>Persisting Authentication (Using cf tokens) ##
 
-A far safer way of creating a cfoundry client object without potentially exposing your credentials in source code is to login using vmc and then use the generated auth token to login in. The auth tokens are stored by vmc in ~/.vmc/tokens.yml. The following snippet of ruby code shows how to open this file, select the right auth token and then use it to log in to Cloud Foundry.
+A far safer way of creating a cfoundry client object without potentially exposing your credentials in source code is to login using cf and then use the generated auth token to login in. The auth tokens are stored by cf in ~/.cf/tokens.yml. The following snippet of ruby code shows how to open this file, select the right auth token and then use it to log in to Cloud Foundry.
 
 ~~~ruby
 
@@ -50,14 +50,14 @@ require 'yaml'
 home = ENV['HOME']
 endpoint = 'https://api.cloudfoundry.com'
 
-config = YAML.load File.read("#{home}/.vmc/tokens.yml")
+config = YAML.load File.read("#{home}/.cf/tokens.yml")
 token = CFoundry::AuthToken.from_hash config[endpoint]
 
 client = CFoundry::Client.new endpoint, token
 
 ~~~
 
-Once the client object is created, it can be used in the same fashion as before. 
+Once the client object is created, it can be used in the same fashion as before.
 
 ## <a id='services'></a>Services ##
 
@@ -116,7 +116,7 @@ To create a service instance use the service_instance method;
 
 ~~~ruby
 service = client.service_instance 'my_new_service'
-service.vendor = 'redis' # <- this is the label property of the service 
+service.vendor = 'redis' # <- this is the label property of the service
 service.version = '2.6' # <- if there are multiple versions of the same service, specify the one required
 service.tier = 'free'
 service.create!
@@ -150,7 +150,7 @@ pp client.apps
  #<CFoundry::V1::App 'sidekiq-worker'>,
  #<CFoundry::V1::App 'caldecott'>,
  #<CFoundry::V1::App 'db-sample'>,
- #<CFoundry::V1::App 'go-test'>] 
+ #<CFoundry::V1::App 'go-test'>]
 
 ~~~
 

--- a/source/docs/using/managing-apps/libs/ruby-cfoundry.html.md
+++ b/source/docs/using/managing-apps/libs/ruby-cfoundry.html.md
@@ -38,9 +38,9 @@ client.services.collect { |x| x.description }
 
 ~~~
 
-## <a id='persist-authentication'></a>Persisting Authentication (Using vmc tokens) ##
+## <a id='persist-authentication'></a>Persisting Authentication (Using cf tokens) ##
 
-A far safer way of creating a cfoundry client object without potentially exposing your credentials in source code is to login using vmc and then use the generated auth token to login in. The auth tokens are stored by vmc in ~/.vmc/tokens.yml. The following snippet of ruby code shows how to open this file, select the right auth token and then use it to log in to Cloud Foundry.
+A far safer way of creating a cfoundry client object without potentially exposing your credentials in source code is to login using cf and then use the generated auth token to login in. The auth tokens are stored by cf in ~/.cf/tokens.yml. The following snippet of ruby code shows how to open this file, select the right auth token and then use it to log in to Cloud Foundry.
 
 ~~~ruby
 
@@ -50,14 +50,14 @@ require 'yaml'
 home = ENV['HOME']
 endpoint = 'https://api.cloudfoundry.com'
 
-config = YAML.load File.read("#{home}/.vmc/tokens.yml")
+config = YAML.load File.read("#{home}/.cf/tokens.yml")
 token = CFoundry::AuthToken.from_hash config[endpoint]
 
 client = CFoundry::Client.new endpoint, token
 
 ~~~
 
-Once the client object is created, it can be used in the same fashion as before. 
+Once the client object is created, it can be used in the same fashion as before.
 
 ## <a id='organisations'></a>Organisations ##
 
@@ -68,7 +68,7 @@ An account will always belong to at least one organization. Inspect the organiza
 >> client.organizations
 => [#<CFoundry::V2::Organization '1e3ce9fb-50ac-4d2a-9506-f4d671c00f50'>, #<CFoundry::V2::Organization '77ab28ea-2b6e-4a7f-86c8-2c2df2714535'>]
 
-~~~  
+~~~
 
 ## <a id='spaces'></a>Spaces ##
 
@@ -220,7 +220,7 @@ app.bind client.service_instance_by_name('my_new_redis_service')
 In order for the application to be accessible via http it has to be assigned a route on a domain;
 
 ~~~ruby
-route = client.route 
+route = client.route
 route.domain = client.domains.first # <- pick the first / default route
 route.space = space # <- assign the route to a space
 route.host = 'my-rails-app' # <- this is the part of the url that is prepended to the domain
@@ -254,7 +254,7 @@ Now the application has been uploaded to Cloud Foundry, all that is left is to s
 app.start!
 ~~~~
 
-The call to start is asynchronous, if true and a block is passed to the method then the block gets called with a URL. The url is the location of a real time log that can be requested via HTTP. CFoundry::Client has a method named stream_url which will transfer chunked data from the server; 
+The call to start is asynchronous, if true and a block is passed to the method then the block gets called with a URL. The url is the location of a real time log that can be requested via HTTP. CFoundry::Client has a method named stream_url which will transfer chunked data from the server;
 
 ~~~ruby
 
@@ -264,7 +264,7 @@ app.start!(true) do |url|
 
     while true
       begin
-        client.stream_url(url + "&tail&tail_offset=#{offset}") do |out| 
+        client.stream_url(url + "&tail&tail_offset=#{offset}") do |out|
           offset += out.size
           print out
         end
@@ -297,7 +297,7 @@ app.env['my_env_var'] # <- retrieve the variable
 
 ## <a id='domains'></a>Domains ##
 
-Domains are the base on which routes are created. The default domain for a Cloud Foundry instance is the domain the Cloud Foundry instance is actually on. 
+Domains are the base on which routes are created. The default domain for a Cloud Foundry instance is the domain the Cloud Foundry instance is actually on.
 
 To create a new domain use the 'domain' method on the client class;
 
@@ -305,7 +305,7 @@ To create a new domain use the 'domain' method on the client class;
 
 domain = client.domain
 domain.name = 'mydomain.com' # <- the name of the domain
-domain.wildcard = true 
+domain.wildcard = true
 domain.owning_organization = client.organizations.first # <- set the owning organisation
 domain.create! # <- commit
 

--- a/source/docs/using/managing-apps/orgs-and-spaces.html.md
+++ b/source/docs/using/managing-apps/orgs-and-spaces.html.md
@@ -10,12 +10,12 @@ Organizations and Spaces are the main organizational "units" in which applicatio
 
 ## <a id='organizations'></a>Organizations ##
 
-An organization is the top-most meta object within the Cloud Foundry infrastructure. If an account has administrative privileges on a Cloud Foundry instance, it can manage it's organizations. 
+An organization is the top-most meta object within the Cloud Foundry infrastructure. If an account has administrative privileges on a Cloud Foundry instance, it can manage it's organizations.
 
 ## <a id='spaces'></a>Spaces ##
 
-An organization can contain multiple spaces, the default for a standard Cloud Foundry install is 'development', 'test' and 'production'. A domain can be mapped to multiple spaces but a route can only be mapped to one application instance and therefore one space. 
+An organization can contain multiple spaces, the default for a standard Cloud Foundry install is 'development', 'test' and 'production'. A domain can be mapped to multiple spaces but a route can only be mapped to one application instance and therefore one space.
 
 ## <a id='managmement'></a>Management ##
 
-Spaces and Organizations can be managed via [VMC](vmc/#commands) or via one of the available [API libraries](libs/). 
+Spaces and Organizations can be managed via [CF](cf/#commands) or via one of the available [API libraries](libs/).

--- a/source/docs/using/tunnelling-with-services.html.md
+++ b/source/docs/using/tunnelling-with-services.html.md
@@ -8,16 +8,16 @@ Any provisioned service on Cloud Foundry is not directly accessible to the outsi
 
 To gain access to a service from outside of the Cloud Foundry ecosystem, a technique called tunneling is used. This means deploying a special application, called Caldecott, to a Cloud Foundry account. The application then binds and connects to the desired service and proxies a connection over HTTP to the service. Once deployed, Caldecott remains available for the creation of tunnels.
 
-Once established, the tunnel can be used by a client, most likely vmc. The client makes a port on the loopback adapter (127.0.0.1) available to use with a native client of the bound service.
+Once established, the tunnel can be used by a client, most likely cf. The client makes a port on the loopback adapter (127.0.0.1) available to use with a native client of the bound service.
 
 ## <a id='creating-a-tunnel'></a>Creating a tunnel ##
 
 The following example illustrates creating a tunnel to a MySQL database and then using mysqldump to create a back up of the database, even though it will be empty!
 
-Create a service instance with vmc;
+Create a service instance with cf;
 
 <pre class="terminal">
-$ vmc create-service
+$ cf create-service
 1: blob 0.51
 2: mongodb 2.0
 3: mysql 5.1
@@ -33,10 +33,10 @@ Name?> mysql-a7cc7
 Creating service mysql-a7cc7... OK
 </pre>
 
-Tunnel to the service with vmc, select mysqldump for the client and give a file path (mydb.sql) to dump to;
+Tunnel to the service with cf, select mysqldump for the client and give a file path (mydb.sql) to dump to;
 
 <pre class="terminal">
-$ vmc tunnel mysql-a7cc7
+$ cf tunnel mysql-a7cc7
 1: none
 2: mysql
 3: mysqldump
@@ -50,7 +50,7 @@ Output file> mydb.sql
 The dump is succesfully writen to mydb.sql. At this point the tunnel has closed, however if option one - none is selected then the tunnel will be held open indefinitely supplying the connection details;
 
 <pre class="terminal">
-$ vmc tunnel mysql-a7cc7
+$ cf tunnel mysql-a7cc7
 1: none
 2: mysql
 3: mysqldump

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -4,7 +4,7 @@ title: Welcome to Cloud Foundry Documentation
 
 This set of materials will replace all Cloud Foundry documentation, for cloudfoundry.com, vcap, and bosh, in Q1 of 2013.
 
-This information is forward-looking and favors 'next generation' components which may not be applicable to existing Cloud Foundry installations. 
+This information is forward-looking and favors 'next generation' components which may not be applicable to existing Cloud Foundry installations.
 
 Docs are a work in progress. We welcome your [contributions](http://github.com/cloudfoundry/cf-docs).
 
@@ -28,12 +28,12 @@ For developers pushing applications to Cloud Foundry.
 
 * [Managing Apps](docs/using/managing-apps/index.html)
 
-  * [vmc](docs/using/managing-apps/vmc/index.html)
+  * [cf](docs/using/managing-apps/cf/index.html)
 
   * [Organizations & Spaces](docs/using/managing-apps/orgs-and-spaces.html)
 
   * [IDE Integration](docs/using/managing-apps/ide/index.html)
-  
+
   * [Build Tools](docs/using/managing-apps/build-tools/index.html)
 
   * [API and Libraries](docs/using/managing-apps/libs/index.html)


### PR DESCRIPTION
`vmc` is getting renamed.  We went ahead and changed it in the relevant places in the documentation.

Chris & Ian
