### PR TITLE
Updated Reference Section for BOSH

### DIFF
--- a/source/docs/running/bosh/reference/blobs.html.md
+++ b/source/docs/running/bosh/reference/blobs.html.md
@@ -1,0 +1,61 @@
+---
+title: Blobs
+---
+
+To create final releases you need to configure your release repository with a blobstore. This is where BOSH will upload the final releases to, so that the release can later be retreived from another computer.
+
+To prevent the release repository from becoming bloated with large binary files (source tar-balls), large files can be placed in the `blobs` directory, and then uploaded to the blobstore.
+
+For production releases you should use either the Atmos or S3 blobstore and configure them as described below.
+
+### Atmos ###
+
+Atmos is a shared storage solution from EMC. To use Atmos, edit `config/final.tml` and `config/private.yml`, and add the following (replacing the `url`, `uid` and `secret` with your account information):
+
+File `config/final.yml`
+
+    ---
+    blobstore:
+      provider: atmos
+      options:
+        tag: BOSH
+        url: https://blob.cfblob.com
+        uid: 1876876dba98981ccd091981731deab2/user1
+
+File `config/private.yml`
+
+    ---
+    blobstore_secret: ahye7dAS93kjWOIpqla9as8GBu1=
+
+### S3 ###
+
+To use S3, a shared storage solution from Amazon, edit `config/final.tml` and `config/private.yml`, and add the following (replacing the `access_key_id`, `bucket_name`, `encryption_key` and `secret_access_key` with your account information):
+
+File `config/final.yml`
+
+    ---
+    blobstore:
+      provider: s3
+      options:
+        access_key_id: KIAK876234KJASDIUH32
+        bucket_name: 87623bdc
+        encryption_key: sp$abcd123$foobar1234
+
+File `config/private.yml`
+
+    ---
+    blobstore_secret: kjhasdUIHIkjas765/kjahsIUH54asd/kjasdUSf
+
+### Local ###
+
+If you are trying out BOSH and don't have an Atmos or S3 account, you can use the local blobstore provider (which stored the files on disk instead of a remote server).
+
+File `config/final.yml`
+
+    ---
+    blobstore:
+      provider: local
+      options:
+        blobstore_path: /path/to/blobstore/directory
+
+Note that local should **only** be used for testing purposes as it can't be shared with others (unless they run on the same system).

--- a/source/docs/running/bosh/reference/config.html.md
+++ b/source/docs/running/bosh/reference/config.html.md
@@ -1,0 +1,7 @@
+---
+title: Config
+---
+
+# Config #
+
+

--- a/source/docs/running/bosh/reference/index.html.md
+++ b/source/docs/running/bosh/reference/index.html.md
@@ -2,8 +2,31 @@
 title: BOSH Reference 
 ---
 
-* [Jobs](jobs.html)
-* [Packages](packages.html)
-* [Releases](releases.html)
+##Bosh Release 
+
+A release is a collection of source code, configuration files and startup scripts used to run services, along with a version number that uniquely identifies the components. When creating a new release, you should use a source code manager (like [git](http://git-scm.com/)) to manage new versions of the contained files.
+
+## Release Repository ##
+
+A BOSH Release is built from a directory tree with the contents described in this section. A typical release repository has the following sub-directories:
+
+| Directory 	| Contents 	|
+| ------------	| ----------	|
+| `jobs` 	| job definitions 	|
+| `packages` 	| package definitions 	|
+| `config` 	| release configuration files 	|
+| `releases` 	| final releases 	|
+| `src` 	| source code for packages 	|
+| `blobs` 	| large source code bundles 	|
+
+* [jobs](jobs.html)
+* [packages](packages.html)
+* [config](config.html)
+* [releases](releases.html)
+* [src](src.html)
+* [blobs](blobs.html)
+
+##Bosh CLI
+
 * [BOSH CLI](bosh-cli.html) 
 

--- a/source/docs/running/bosh/reference/jobs.html.md
+++ b/source/docs/running/bosh/reference/jobs.html.md
@@ -2,4 +2,48 @@
 title: Jobs
 ---
 
-Coming soon...
+## Jobs ##
+
+Jobs are realization of packages, i.e. running one or more processes from a package. A job contains the configuration files and startup scripts to run the binaries from a package.
+
+There is a *manyto many* mapping between jobs and VMs - one or more jobs can run in any given VM and many VMs can run the same job. E.g. there can be four VMs running the Cloud Controller job, the Cloud Controller job and the DEA job can also run on the same VM. If you need to run two different processes (from two different packages) on the same VM, you need to create a job which starts both processes.
+
+### Prepare script ###
+
+If a job needs to assemble itself from other jobs (like a super-job) a `prepare` script can be used, which is run before the job is packaged up, and can create, copy or modify files.
+
+### Job templates ###
+
+The job templates are generalized configuration files and scripts for a job, which uses [ERB](http://ruby-doc.org/stdlib-1.9.3/libdoc/erb/rdoc/ERB.html) files to generate the final configuration files and scripts used when a Stemcell is turned into a job.
+
+When a configuration file is turned into a template, instance specific information is abstracted into a property which later is provided when the [director][director] starts the job on a VM. E.g. which port the webserver should run on, or which username and password a databse should use.
+
+The files are located in the `templates` directory and the mapping between template file and its final location is provided in the job `spec` file in the templates section. E.g.
+
+    templates:
+      foo_ctl.erb: bin/foo_ctl
+      foo.yml.erb: config/foo.yml
+      foo.txt: config/foo.txt
+
+### Use of properties ###
+
+The properties used for a job comes from the deployment manifest, which passes the instance specific information to the VM via the [agent][agent].
+
+### "the job of a vm" ###
+
+When a VM is first started, is a Stemcell, which can become any kind of job. It is first when the director instructs the VM to run a job as it will gets its *personality*.
+
+### Monitrc ###
+
+BOSH uses [monit](http://mmonit.com/monit/) to manage and monitor the process(es) for a job. The `monit` file describes how the BOSH [agent][agent] will stop and start the job, and it contains at least three sections:
+
+`with pidfile`
+: Where the process keeps its pid file
+
+`start program`
+: How monit should start the process
+
+`stop program`
+: How monit should stop the process
+
+Usually the `monit` file contain a script to invoke to start/stop the process, but it can invoke the binary directly.

--- a/source/docs/running/bosh/reference/packages.html.md
+++ b/source/docs/running/bosh/reference/packages.html.md
@@ -2,5 +2,42 @@
 title: Packages
 ---
 
-Coming soon...
+## Packages ###
+
+A package is a collection of source code along with a script that contains instruction how to compile it to binary format and install it, with optional dependencies on other pre-requisite packages.
+
+### Package Compilation ###
+
+Packages are compiled on demand during the deployment. The [director](#bosh-director) first checks to see if there already is a compiled version of the package for the stemcell version it is being deployed to, and if it doesn't already exist a compiled version, the director will instantiate a compile VM (using the same stemcell version it is going to be deployed to) which will get the package source from the blobstore, compile it, and then package the resulting binaries and store it in the blobstore.
+
+To turn source code into binaries, each package has a `packaging` script that is responsible for the compilation, and is run on the compile VM. The script gets two environment variables set from the BOSH agent:
+
+`BOSH_INSTALL_TARGET`
+: Tells where to install the files the package generates. It is set to `/var/vcap/data/packages/<package name>/<package version>`.
+
+`BOSH_COMPILE_TARGET`
+: Tells the the directory containing the source (it is the current directory when the `packaging` script is invoked).
+
+When the package is installed a symlink is created from `/var/vcap/packages/<package name>` which points to the latest version of the package. This link should be used when referring to another package in the `packaging` script.
+
+There is an optional `pre_packaging` script, which is run when the source of the package is assembled during the `bosh create release`. It can for instance be used to limit which parts of the source that get packages up and stored in the blobstore. It gets the environment variable `BUILD_DIR` set by the BOSH CLI which is the directory containing the source to be packaged.
+
+### Package specs ###
+
+The package contents are specified in the `spec` file, which has three sections:
+
+`name`
+: The name of the package.
+
+`dependencies`
+: An optional list of other packages this package depends on, [see below][Dependencies].
+
+`files`
+: A list of files this package contains, which can contain globs. A `*` matches any file and can be restricted by other values in the glob, e.g. `*.rb` only matches files ending with `.rb`. A `**` matches directories recursively.
+
+### Dependencies ###
+
+The package `spec` file contains a section which lists other packages the current package depends on. These dependencies are compile time dependencies, as opposed to the job dependencies which are runtime dependencies.
+
+When the [director](#bosh-director) plans the compilation of a package during a deployment, it first makes sure all dependencies are compiled before it proceeds to compile the current package, and prior to commencing the compilation all dependent packages are installed on the compilation VM.
  

--- a/source/docs/running/bosh/reference/releases.html.md
+++ b/source/docs/running/bosh/reference/releases.html.md
@@ -2,4 +2,15 @@
 title: Releases
 ---
 
-Coming soon...
+The `releases` folder contains the `yml` file declaring the content of the release : `packages` and their dependencies.
+
+Sample release file is show below
+
+	--- 
+	packages: 
+	- name: my package
+	  version: 1
+      sha1: 0b01b20d81a0044e22fd0b335cf93922936a7f7d
+      dependencies: []
+      ….
+

--- a/source/docs/running/bosh/reference/src.html.md
+++ b/source/docs/running/bosh/reference/src.html.md
@@ -1,0 +1,7 @@
+---
+title: src
+---
+
+# src #
+
+The source folder from which the release is created.


### PR DESCRIPTION
Updated the references section with more detail about Release, Jobs, Packages, Blobs.

Note : Some of this content existed in the older docs in another format
