### PR TITLE
Default db_scheme

### DIFF
--- a/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md
+++ b/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md
@@ -238,6 +238,7 @@ jobs:
     db: ccdb_ng
 
 - name: uaadb
+  db_scheme: postgresql
   release: appcloud
   template: postgres
   instances: 1


### PR DESCRIPTION
Add default db_scheme key to example cloudfoundry manifest.
