### PR TITLE
Clarify values in bosh_environment

### DIFF
--- a/source/docs/running/deploying-cf/ec2/index.html.md
+++ b/source/docs/running/deploying-cf/ec2/index.html.md
@@ -54,6 +54,9 @@ export BOSH_AWS_SECRET_ACCESS_KEY=your_secret_asdf34dfg
 export BOSH_VPC_SECONDARY_AZ=us-east-1a # see note below
 export BOSH_VPC_PRIMARY_AZ=us-east-1d   # see note below
 ~~~
+
+Note: `BOSH_VPC_DOMAIN` and `BOSH_VPC_SUBDOMAIN` must correspond to the DNS domain name you set up when configuring Route 53. The values shown above correspond to the earlier Route 53 example of *cloud.mydomain.com*.
+
 Note: Choose availability zones which are listed as "operating normally" on the [AWS Console Status Health Section](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1).
 
 Use `source` to set them for the current shell:


### PR DESCRIPTION
While setting up my bosh_environment file, the comment to "pick something more unique than 'cloud'..." for BOSH_VPC_SUBDOMAIN confused me. I did not realize that it needed to correspond exactly with the subdomain I set up in Route 53. Figured this out by trial and error.

This clarification should eliminate that source of confusion for future users.
