### PR TITLE
Update docs for deploying a microbosh

### DIFF
--- a/source/docs/running/bosh/setup/index.html.md
+++ b/source/docs/running/bosh/setup/index.html.md
@@ -1,5 +1,5 @@
 ---
-title: BOSH Local Setup
+title: BOSH CLI Local Setup
 ---
 
 BOSH CLI is a command line interface used to interact with MicroBOSH and BOSH. Before you can use MicroBOSH or BOSH you need to install BOSH Command Line Interface. The following steps install BOSH CLI. You can install on either a physical or virtual machine.
@@ -22,20 +22,3 @@ If you are using the rbenv Ruby environment manager, refresh the list of gems th
 <pre class="terminal">
 $ rbenv rehash
 </pre>
-
-## Install BOSH Releases ##
-
-Clone the BOSH and bosh-release repositories in git:
-
-<pre class="terminal">
-$ git clone git@github.com:cloudfoundry/bosh.git
-$ git clone git@github.com:cloudfoundry/bosh-release.git
-</pre>
-
-Get release 11 from a branch of bosh-release (we are using an old commit during transition to new release functionality):
-
-<pre class="terminal">
-$ cd bosh-release
-$ git checkout 9e0b649da80a563ba64229069299c57f72ab54ad
-</pre>
-

--- a/source/docs/running/bosh/setup/index.html.md
+++ b/source/docs/running/bosh/setup/index.html.md
@@ -14,7 +14,7 @@ BOSH CLI is a command line interface used to interact with MicroBOSH and BOSH. B
 Install the BOSH CLI gem:
 
 <pre class="terminal">
-$ gem install bosh_cli
+$ gem install bosh_cli "~> 1.5.0.pre" --source https://s3.amazonaws.com/bosh-jenkins-gems/
 </pre>
 
 If you are using the rbenv Ruby environment manager, refresh the list of gems that rbenv knows about: 

--- a/source/docs/running/bosh/setup/index.html.md
+++ b/source/docs/running/bosh/setup/index.html.md
@@ -6,8 +6,8 @@ BOSH CLI is a command line interface used to interact with MicroBOSH and BOSH. B
 
 ## Prerequisites ##
 
-* [Install Ruby and RubyGems](/docs/common/install_ruby.html). 
-* [Install a Git client](/docs/common/install_git.html) to pull down the BOSH repository from GitHub. 
+* [Install Ruby and RubyGems](/docs/common/install_ruby.html). Requires Ruby 1.9.3 or Ruby 2.0.0.
+* [Install a Git client](/docs/common/install_git.html) to pull down BOSH repositories from GitHub. 
 
 ## Install Local BOSH ##
 


### PR DESCRIPTION
https://github.com/cloudfoundry/cf-docs/blob/master/source/docs/running/bosh/setup/index.html.md references bosh-release repo; and it doesn't really explain how to get microbosh deployed.

Perhaps change it into a ToC for CPI-specific microbosh deployments
