### PR TITLE
Link to "deploy services" page broken from home

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -105,7 +105,7 @@ title: Welcome to Cloud Foundry Documentation
   <a href="docs/running/deploying-cf/openstack/index.html">Deploy to OpenStack</a><br>   
   <a href="docs/running/deploying-cf/vsphere/index.html">Deploy to vSphere</a><br>
   <a href="docs/running/deploying-cf/vcloud/deploying_to_vcloud_director.html">Deploy to vCloud Director</a><br>
-  <a href="docs/running/deploying-cf/services/adding-services.html">Adding Services</a><br>
+  <a href="docs/running/deploying-cf/services/">Adding Services</a><br>
   <br>
   <a href="docs/running/deploying-cf-with-chef/index.html">Deploy with Chef</a><br>
   <a href="docs/running/deploying-cf/run-local.html">Run a Local Cloud Foundry Instance</a>


### PR DESCRIPTION
I thinik it was caused by https://github.com/cloudfoundry/cf-docs/commit/5a98739558b8214a400d7cc347b1f0b17a3066e7#source/docs/running/deploying-cf/services/index.html.md
