### PR TITLE
Update to Deploying CF on OpenStack

### DIFF
--- a/source/docs/running/deploying-cf/common/cf-release.html.md
+++ b/source/docs/running/deploying-cf/common/cf-release.html.md
@@ -49,14 +49,11 @@ Check the release has been added successfully by issuing the follow command;
 <pre class="terminal">
 $ bosh releases
 
-+----------+------------+-------------+
-| Name     | Versions   | Commit Hash |
-+----------+------------+-------------+
-| appcloud | 131.1-dev  | de134222+   |
-+----------+------------+-------------+
-(*) Currently deployed
-
-Releases total: 1
++------+----------+-------------+
+| Name | Versions | Commit Hash |
++------+----------+-------------+
+| cf   | 138      | adca9c45    |
++------+----------+-------------+
 </pre>
 
-This release is now ready to deploy using a custom manifest.
+This release is now ready to deploy using a deployment file.

--- a/source/docs/running/deploying-cf/common/cf-release.html.md
+++ b/source/docs/running/deploying-cf/common/cf-release.html.md
@@ -8,113 +8,39 @@ title: Using the latest CF-Release
 
 This short guide shows how to, after [bootstrapping Bosh](/docs/running/deploying-cf/), create a Cloud Foundry release ready to deploy to your environment. 
 
+NOTE: These instructions are for v138 release of Cloud Foundry.
+
 ## <a id='clone'></a> Clone CF-Release ##
 
 Create / find a folder to keep your clone of the CF-Release repository and clone it from Github;
 
 <pre class="terminal">
-$ mkdir -p ~/src/cloudfoundry && cd ~/src/cloudfoundry
-$ git clone -b release-candidate git://github.com/cloudfoundry/cf-release.git && cd cf-release
-
-</pre>
-
-## <a id='update'></a> Update the release ##
-
-Run the included update script, ~/src/cloudfoundry/cf-release/update;
-
-<pre class="terminal">
-$ ./update
-+ git pull
-remote: Counting objects: 96, done.
-remote: Compressing objects: 100% (42/42), done.
-remote: Total 67 (delta 43), reused 45 (delta 25)
-Unpacking objects: 100% (67/67), done.
-From http://github.com/cloudfoundry/cf-release
-   abd53f7..3be3d09  master     -> origin/master
-Fetching submodule src/dea_next
-remote: Counting objects: 61, done.
-remote: Compressing objects: 100% (20/20), done.
-remote: Total 40 (delta 22), reused 36 (delta 18)
-Unpacking objects: 100% (40/40), done.
-From https://github.com/cloudfoundry/dea_ng
-   aa33fd9..2ca4fcd  master     -> origin/master
-Fetching submodule src/dea_next/buildpacks/vendor/java
-remote: Counting objects: 73, done.
-remote: Compressing objects: 100% (21/21), done.
-remote: Total 65 (delta 9), reused 62 (delta 6)
-Unpacking objects: 100% (65/65), done.
-From https://github.com/cloudfoundry/cloudfoundry-buildpack-java
-   663e463..09875f7  master     -> origin/master
-Updating abd53f7..3be3d09
-warning: unable to rmdir src/logplex: Directory not empty
-Fast-forward
- config/blobs.yml                                   |   16 +-
- jobs/dea_next/templates/drain.rb                   |    2 +-
- jobs/log_server/monit                              |    5 -
-
-...
-
-Submodule path 'src/services': checked out '106ad12b8d21b72ae46379608df2efc8c43f3563'
-Submodule 'govendor' (https://github.com/cloudfoundry/vcap-services.git) registered for path 'govendor'
-Submodule 'assets' (https://github.com/cloudfoundry/vcap-yeti.git) registered for path 'assets'
-</pre>
-
-This is a very simple script that just runs a 'git pull' on the repository and then updates all the submodules. CF-Release is a combination of various other repositories.
-
-
-## <a id='build-the-release'></a> Build the release ##
-
-At this point if the Bosh CLI is not installed on the local system and targeted at a BOSH / MicroBOSH instance, do so, 
-if necessary use this install [guide](/docs/running/bosh/setup/).
-
-When prompted, name your release `appcloud`:
-
-<pre class="terminal">
-$ bosh create release --force
-Syncing blobs...
-
-Please enter development release name: appcloud
-
-Building DEV release
----------------------------------
-
-Building packages
------------------
-Building backup_manager...
-  Final version:   NOT FOUND
-  Dev version:     FOUND LOCAL
-
-Building bandwidth_proxy...
-  Final version:   FOUND LOCAL
-
-Building buildpack_cache...
-  Final version:   NOT FOUND
-  Dev version:     FOUND LOCAL
-
-...
-
-Release version: 131.1-dev
-Release manifest: /private/tmp/cf-release/dev_releases/appcloud-131.1-dev.yml
+mkdir -p ~/bosh-workspace/releases
+cd ~/bosh-workspace/releases
+git clone -b release-candidate git://github.com/cloudfoundry/cf-release.git
+cd cf-release
 </pre>
 
 ## <a id='upload-the-release'></a> Upload the release ##
 
-Once the build is complete, the latest development release (that was just generated), can be uploaded to the BOSH / MicroBOSH instance;
+Releases of Cloud Foundry are published regularly (approximately weekly) and you upload them to your bosh using `bosh upload release`:
 
 <pre class="terminal">
-$ bosh upload release
+$ bosh upload release releases/cf-138.yml
 
+Copying packages
+----------------
+rootfs_lucid64 (1)            FOUND LOCAL
 ...
-
-Uploading release
-
+Copying jobs
+------------
+saml_login (4)                FOUND LOCAL
 ...
-
-Task 11 done
-Started   2013-03-22 23:07:16 UTC
-Finished  2013-03-22 23:07:23 UTC
-Duration  00:00:07
-
+Building tarball
+----------------
+Generated /tmp/d20130829-912-fq3kkd/d20130829-912-1vco0hv/release.tgz
+Release size: 1.0G
+...
 Release uploaded
 </pre>
 

--- a/source/docs/running/deploying-cf/openstack/deploying_microbosh.html.md
+++ b/source/docs/running/deploying-cf/openstack/deploying_microbosh.html.md
@@ -28,7 +28,9 @@ Although the new [OpenStack Networking](http://www.openstack.org/software/openst
 
 Check that your OpenStack `default` security group allows SSH (port `22`). Create a new OpenStack security group, name it ie `microbosh`, and open the following ports:
 
-* All ports (from `1` to `65535`) where the source group is the current security group 
+* All ports (from `1` to `65535`) where the source group is the current security group
+* Port `22` from source 0.0.0.0/0 (CIDR): Used for inbound SSH access
+* Port `53` from source 0.0.0.0/0 (CIDR): Used for inbound DNS requests
 * Port `4222` from source 0.0.0.0/0 (CIDR): Used by [NATS](/docs/running/bosh/components/messaging.html)
 * Port `6868` from source 0.0.0.0/0 (CIDR): Used by [BOSH Agent](/docs/running/bosh/components/agent.html)
 * Port `25250` from source 0.0.0.0/0 (CIDR): Used by [BOSH Blobstore](/docs/running/bosh/components/blobstore.html)

--- a/source/docs/running/deploying-cf/openstack/deploying_microbosh.html.md
+++ b/source/docs/running/deploying-cf/openstack/deploying_microbosh.html.md
@@ -220,7 +220,7 @@ cd ~/bosh-workspace/stemcells
 Download the latest OpenStack Micro BOSH stemcell:
 
 <pre class="terminal">
-wget http://bosh-jenkins-artifacts.s3.amazonaws.com/micro-bosh-stemcell/openstack/latest-micro-bosh-stemcell-openstack.tgz
+wget http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz
 </pre>
 
 ### <a id="deploy"></a>Deploy Micro BOSH ###
@@ -240,7 +240,7 @@ This command will output:
 Deploy the Micro BOSH:
 
 <pre class="terminal">
-bosh micro deploy ~/bosh-workspace/stemcells/latest-micro-bosh-stemcell-openstack.tgz
+bosh micro deploy ~/bosh-workspace/stemcells/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz
 </pre>
  
 This command will output:

--- a/source/docs/running/deploying-cf/openstack/deploying_microbosh.html.md
+++ b/source/docs/running/deploying-cf/openstack/deploying_microbosh.html.md
@@ -258,8 +258,8 @@ This command will output:
     
     Stemcell info
     -------------
-    Name:    micro-bosh-stemcell
-    Version: 1.5.0.pre.3
+    Name:    bosh-stemcell
+    Version: 939
     
     
     Deploy Micro BOSH

--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -77,21 +77,18 @@ Confirm that you have a release "cf" uploaded:
 <pre class="terminate">
 $ bosh releases
 
-+----------+------------+-------------+
-| Name     | Versions   | Commit Hash |
-+----------+------------+-------------+
-| appcloud | 131.1-dev  | de134222+   |
-+----------+------------+-------------+
-(*) Currently deployed
-
-Releases total: 1
++------+----------+-------------+
+| Name | Versions | Commit Hash |
++------+----------+-------------+
+| cf   | 138      | adca9c45    |
++------+----------+-------------+
 </pre>
 
 ## Upload a base stemcell ##
 
 A cloud provider needs a base image to provision VMs/servers. Bosh explicitly requires that the base image includes the [Agent](../../bosh/components/agent.html). Therefore, we use specific base images which are known to have a bosh agent installed. These base images are called `bosh stemcells`.
 
-To download the latest bosh stemcell and upload it to your bosh:
+To upload the latest bosh stemcell to your bosh:
 
 <pre class="terminate">
 $ wget http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/latest-bosh-stemcell-openstack.tgz

--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -479,11 +479,11 @@ properties:
         secret: <%= common_password %>
         authorized-grant-types: client_credentials
         authorities: clients.read,clients.write,clients.secret,password.write,scim.read,uaa.admin
-      scim:
-        userids_enabled: true
-        users:
-        - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin,uaa.admin,password.write
-        - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
+    scim:
+      userids_enabled: true
+      users:
+      - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin,uaa.admin,password.write
+      - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
 ~~~
 
 NOTE again: this is a deployment file that is known to work with v138 of Cloud Foundry.

--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -4,6 +4,8 @@ title: Install Cloud Foundry on OpenStack
 
 In this page you will run Cloud Foundry on OpenStack.
 
+NOTE: These instructions are for v138 release of Cloud Foundry. For newer versions of Cloud Foundry, [please let us know](https://github.com/cloudfoundry/cf-docs/issues/new) if this documentation continues to work or needed some changes.
+
 ## What will happen ##
 
 At the end of this page, three `m1.medium` VMs will be running in your OpenStack environment running Cloud Foundry.
@@ -39,9 +41,9 @@ Config
 Director
   Name       firstbosh
   URL        https://1.2.3.4:25555
-  Version    1.5.0.pre.3 (release:49d2d498 bosh:49d2d498)
+  Version    1.5.0.pre.939 (release:930f73f5 bosh:930f73f5)
   User       admin
-  UUID       7a462ebe-bdb7-4e7c-b096-c42736XXXXXX
+  UUID       18bbfe79-6ccf-4020-b1c7-6f19d67a8c9c
   CPI        openstack
   dns        enabled (domain_name: microbosh)
   compiled_package_cache disabled
@@ -70,7 +72,7 @@ You can now create and upload the Cloud Foundry bosh release ([cf-release](https
 
 [Follow these instructions.](../common/cf-release.html)
 
-Confirm that you have a release "appcloud" uploaded:
+Confirm that you have a release "cf" uploaded:
 
 <pre class="terminate">
 $ bosh releases

--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -109,6 +109,16 @@ $ bosh stemcells
 Stemcells total: 1
 </pre>
 
+## Other preparation
+
+OpenStack uses security groups for restricting/allowing ports to a set of servers.
+
+You need to create a security group `cf`:
+
+* allow all ports to talk to all ports of servers using the same `cf` security group
+* allow port 22 for administrator SSH access
+* allow 80 for HTTP traffic (primarily for the router)
+
 ## Create a minimal deployment file ##
 
 The next step towards deploying Cloud Foundry is to create a `deployment file`. This is a YAML file that describes exactly what will be included in the next deployment. This includes:
@@ -147,7 +157,7 @@ TODO, change the following at the top of the file:
 * replace `root_domain` value with a DNS, say `mycloud.com` that has `*.mycloud.com` mapped to your IP; defaults to using http://xip.io service for DNS
 * replace the `common_password`; even better is to put in lots of different passwords and tokens throughout the deployment file
 
-<pre>
+~~~yaml
 ---
 <%
 director_uuid = "DIRECTOR_UUID"
@@ -474,8 +484,7 @@ properties:
         users:
         - admin|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin,uaa.admin,password.write
         - services|<%= common_password %>|scim.write,scim.read,openid,cloud_controller.admin
-
-</pre>
+~~~
 
 NOTE again: this is a deployment file that is known to work with v138 of Cloud Foundry.
 

--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -157,7 +157,7 @@ TODO, change the following at the top of the file:
 * replace `root_domain` value with a DNS, say `mycloud.com` that has `*.mycloud.com` mapped to your IP; defaults to using http://xip.io service for DNS
 * replace the `common_password`; even better is to put in lots of different passwords and tokens throughout the deployment file
 
-~~~yaml
+~~~
 ---
 <%
 director_uuid = "DIRECTOR_UUID"

--- a/source/docs/running/deploying-cf/openstack/uploading_bosh_stemcell.html.md
+++ b/source/docs/running/deploying-cf/openstack/uploading_bosh_stemcell.html.md
@@ -18,36 +18,43 @@ bosh upload stemcell http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcel
 
 This command will output:
 
-    Using remote stemcell `http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz'
+<pre class="terminal">
 
-    Uploading stemcell...
+Using remote stemcell `http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz'
 
-    Director task 1
+Uploading stemcell...
 
-    Update stemcell
-      downloading remote stemcell (00:00:49)
-      extracting stemcell archive (00:00:04)
-      verifying stemcell manifest (00:00:00)
-      checking if this stemcell already exists (00:00:00)
-      uploading stemcell bosh-stemcell/1.5.0.pre.3 to the cloud (00:01:18)
-      save stemcell bosh-stemcell/1.5.0.pre.3 (72f212a7-657c-4bd0-ad6b-ce1fdd454b0f) (00:00:00)
-    Done                    6/6 00:02:11
+Director task 1
 
-    Task 1 done
-    Started		2013-07-01 08:24:10 UTC
-    Finished	2013-07-01 08:26:21 UTC
-    Duration	00:02:11
+Update stemcell
+  downloading remote stemcell (00:00:49)
+  extracting stemcell archive (00:00:04)
+  verifying stemcell manifest (00:00:00)
+  checking if this stemcell already exists (00:00:00)
+  uploading stemcell bosh-stemcell/939 to the cloud (00:00:27)                                      
+  save stemcell bosh-stemcell/939 (2214e824-e420-4a43-ac81-b6f600f25f80) (00:00:00)                 
+Done                    6/6 00:02:11
 
-    Stemcell uploaded and created
+Task 1 done
+Started		2013-07-01 08:24:10 UTC
+Finished	2013-07-01 08:26:21 UTC
+Duration	00:02:11
+
+Stemcell uploaded and created
+</pre>
 
 ## <a id="check_stemcell"></a>Check BOSH Stemcell ###
 
 To confirm that the BOSH Stemcell has been loaded into your BOSH Director use the `bosh stemcells` command:
    
-    +---------------+-------------+--------------------------------------+
-    | Name          | Version     | CID                                  |
-    +---------------+-------------+--------------------------------------+
-    | bosh-stemcell | 1.5.0.pre.3 | 72f212a7-657c-4bd0-ad6b-ce1fdd454b0f |
-    +---------------+-------------+--------------------------------------+
-    
-    Stemcells total: 1
+<pre class="terminal">
+# bosh stemcells
++---------------+---------+--------------------------------------+
+| Name          | Version | CID                                  |
++---------------+---------+--------------------------------------+
+| bosh-stemcell | 939     | 2214e824-e420-4a43-ac81-b6f600f25f80 |
++---------------+---------+--------------------------------------+
+
+Stemcells total: 1
+</pre>
+

--- a/source/docs/running/deploying-cf/openstack/uploading_bosh_stemcell.html.md
+++ b/source/docs/running/deploying-cf/openstack/uploading_bosh_stemcell.html.md
@@ -13,12 +13,12 @@ A Micro BOSH or Full BOSH should be deployed and targeted. See the steps in [Dep
 Upload a BOSH Stemcell to the BOSH Director using the `bosh upload` command:
 
 <pre class="terminal">
-bosh upload stemcell http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/latest-bosh-stemcell-openstack.tgz
+bosh upload stemcell http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz
 </pre>
 
 This command will output:
 
-    Using remote stemcell `http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/latest-bosh-stemcell-openstack.tgz'
+    Using remote stemcell `http://bosh-jenkins-artifacts.s3.amazonaws.com/bosh-stemcell/openstack/bosh-stemcell-latest-openstack-kvm-ubuntu.tgz'
 
     Uploading stemcell...
 


### PR DESCRIPTION
- Updates the common "install cf-release" to use v138 final release.
- Explicitly states that v138 is the version being documented
- Documents the known ports
