### PR TITLE
[openstack] dea needs to know if ssl or not

### DIFF
--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -340,6 +340,7 @@ properties:
     memory_overcommit_factor: 4
     disk_mb: 16384
     disk_overcommit_factor: 4
+    directory_server_protocol: <%= protocol %>
 
   dea_next: *dea
 


### PR DESCRIPTION
The CLI streams logs via a URL given to it. It has https protocol by default.
Need to configure dea with properties.dea_next.directory_server_protocol:
http or https
