### PR TITLE
add bosh as a dependency

### DIFF
--- a/source/docs/running/deploying-cf/ec2/index.html.md
+++ b/source/docs/running/deploying-cf/ec2/index.html.md
@@ -34,6 +34,7 @@ source 'https://s3.amazonaws.com/bosh-jenkins-gems/'
 ruby "1.9.3"
 
 gem "bootstrap-cf-plugin", :git => "git://github.com/cloudfoundry/bootstrap-cf-plugin"
+gem "bosh"
 ~~~
 
 Install the latest release of the bootstrap plugin.


### PR DESCRIPTION
As the plugin is a dependency of bosh it needs bosh. so it should also be a dependency in the Gemfile. If not you get the following error: 
-bash: bosh: command not found
