### PR TITLE
Update Java documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These docs are rendered using [middleman](https://github.com/middleman/middleman
 git clone https://github.com/cloudfoundry/cf-docs.git cloudfoundry-docs
 cd cloudfoundry-docs
 bundle
-middleman server
+bundle exec middleman server
 ```
 
 Then view [http://0.0.0.0:4567](http://0.0.0.0:4567) in your browser.

--- a/source/docs/dotcom/marketplace/services/newrelic/index.html.md
+++ b/source/docs/dotcom/marketplace/services/newrelic/index.html.md
@@ -19,7 +19,7 @@ $ cf create-service newrelic
 Bind the service instance to your app with the following command:
 
 <pre class="terminal">
-$ cf bind-service 
+$ cf bind-service
 </pre>
 
 ### <a id='sso'></a>Single Sign On ###
@@ -40,19 +40,13 @@ $ cd rails_sample_app
 $ cf push
 </pre>
 
-### <a id='sample-spring'></a>Spring ###
+### <a id='sample-java'></a>Java ###
 
-[This sample Spring app](https://github.com/cloudfoundry-samples/spring-music/tree/newrelic) already has the New Relic agent configured as a dependency in `build.gradle` and the New Relic configuration file in `src/main/resources`. We've also configured `manifest.yml` to set the necessary environment variable when you push the app, but you'll need to edit that file with an actual value for `-Dnewrelic.config.license_key` in `CATALINA_OPTS`. Because we've already got a manifest.yml, we're going to create the New Relic service instance first, update the manifest, then build and push.   
+[This sample Java app](https://github.com/cloudfoundry-samples/spring-music/tree/newrelic) takes advantage of the Java buildpack's zero-touch New Relic support.  The included `manifest.yml` contains configuration to automatically create and bind a new instance of the New Relic service to your application.  All you need to do is clone, build, and push!
 
 <pre class="terminal">
-$ git clone -b newrelic git@github.com:cloudfoundry-samples/spring-music.git
+$ git clone -b newrelic https://github.com:cloudfoundry-samples/spring-music.git
 $ cd spring-music
-$ cf create-service newrelic --name newrelic --plan standard
-</pre>
-
-Log into your New Relic account via SSO [as described above](#sso). Once there, click on Account Settings in the top right. On the right of that page you'll find your New Relic license key. Add the license key to `-Dnewrelic.config.license_key` for `CATALINA_OPTS` in `manifest.yml`.
-
-<pre class="terminal">
 $ ./gradlew assemble
 $ cf push
 </pre>
@@ -73,87 +67,40 @@ All three of these things can be found by logging into your New Relic account as
 
 1. Add the New Relic agent gem to your Gemfile.
 
-  ~~~xml
-  gem 'newrelic_rpm'
-  ~~~
-  Rebuild the bundle if you want to test locally, but this isn't required because Cloud Foundry will bundle the gem when you push your app.
-  <pre class="terminal">
-  $ bundle install
-  </pre>
+	~~~xml
+	gem 'newrelic_rpm'
+	~~~
+	Rebuild the bundle if you want to test locally, but this isn't required because Cloud Foundry will bundle the gem when you push your app.
+	<pre class="terminal">
+	$ bundle install
+	</pre>
 
 1. Add a New Relic configuration file to your project. This file needs to be configured with your license key and application name, but we've modified New Relic's config file for Ruby to automatically read your application name and license key from environment variables which are set when the app is pushed. [Download our modified newrelic.yml here](./newrelic-ruby.yml) and save it to `config/newrelic.yml`.
 
 	<pre class="terminal">
-	$ wget -O config/newrelic.yml http://docs.cloudfoundry.com/docs/dotcom/marketplace/services/newrelic/newrelic-ruby.yml 
+	$ wget -O config/newrelic.yml http://docs.cloudfoundry.com/docs/dotcom/marketplace/services/newrelic/newrelic-ruby.yml
 	</pre>
 
 1. All you have left to do is push your app! If you don't already have a New Relic service instance in your space, choose to create one when prompted. If you already have a New Relic service instance in your space, choose to bind to an existing service when prompted.
-	
+
 	<pre class="terminal">
 	$ cf push
-	</pre> 
+	</pre>
 
 1. Now generate some usage on your app and log into New Relic via SSO [as described above](#sso); you should see data coming through!
 
-### <a id='java'></a>Java / Spring ###
+### <a id='java'></a>Java ###
 
-1. Add the New Relic agent to your project
-
-  For Maven, add the following to `pom.xml`
-
-  ~~~xml
-  <dependency>
-      <groupId>com.newrelic.agent.java</groupId>
-      <artifactId>newrelic-agent</artifactId>
-      <version>2.21.3</version>
-  </dependency>
-  ~~~
-
-  For Gradle, put the following in `build.gradle`
-
-  ~~~xml
-  dependencies {
-      compile 'com.newrelic.agent.java:newrelic-agent:2.21.3'
-  }
-  ~~~
-
-1. Add a New Relic configuration file to your project. [Download newrelic.yml](./newrelic.yml) and save it with your other app config files (e.g. in `src/main/resources/newrelic.yml`). No need to populate application name and license key; we'll set an environment variable to pass them as system parameters to the jvm. This will overwrite the same parameters in the config file.
-
-	<pre class="terminal">
-	$ wget -O src/main/resources/newrelic.yml http://docs.cloudfoundry.com/docs/dotcom/marketplace/services/newrelic/newrelic.yml
-	</pre>
-
-1. Build your app!
-
+1. Build your app.
 1. Push your app to Cloud Foundry. If you don't already have a New Relic service instance in your space, choose to create one when prompted. If you already have a New Relic service instance in your space, choose to bind to an existing service when prompted.
-
 	<pre class="terminal">
 	$ cf push
-	</pre> 
-
-1. Next, we need to get the license key. Log into your New Relic account via SSO [as described above](#sso). Once there, click on Account Settings in the top right. On the right of that page you'll find your New Relic license key. You're going to need it for the next step.
-
-1. Now we're going to set an environment variable to pass system parameters to the jvm. Replace `your_app_name` and `your_license_key` with actual values.
-
-	<pre class="terminal">
-	$ cf set-env <your app name> CATALINA_OPTS "-javaagent:/app/webapps/ROOT/WEB-INF/lib/newrelic-agent-2.21.3.jar 
-		-Dnewrelic.home='/app/webapps/ROOT/WEB-INF/classes' 
-		-Dnewrelic.config.license_key='your_license_key' 
-		-Dnewrelic.config.app_name='your_app_name'
-		-Dnewrelic.config.log_file_path='/home/vcap/logs'"
 	</pre>
+1. Now generate some usage on your app and log into New Relic via SSO [as described above](#sso); you should see data coming through!
 
-1. Finally, restart your app. This will trigger the jvm to pick up the system parameters required for the New Relic agent to be started with the correct configuration.
+---
 
-	<pre class="terminal">
-        $ cf restart <your app name>
-        </pre>
-
-1. Now generate some usage on your app and log into New Relic via SSO described above](#sso); you should see data coming through!
-
-####Cloud Foundry is working on improving the developer experience for New Relic and Java. Stay tuned!
-
-### <a id='vcap-services'></a>VCAP_SERVICES ###
+## <a id='vcap-services'></a>VCAP_SERVICES ##
 
 When you bind your New Relic service instance with your application, Cloud Foundry makes a request to New Relic for the license key for your account. When you restart your application, we write this key to the `VCAP_SERVICES` environment variable.
 
@@ -161,17 +108,17 @@ Format of `VCAP_SERVICES` environment variable:
 
 ~~~xml
 {
-  "newrelic-n/a":[
-    {
-      "name":"newrelic-14e9d",
-      "label":"newrelic-n/a",
-      "plan":"standard",
-      "credentials":
-        {
-          "licenseKey":"2865f6f3nsig8f813af7989fccb24a699cb22a4beb"
-        }
-    }
-  ]
+	"newrelic-n/a":[
+		{
+			"name":"newrelic-14e9d",
+			"label":"newrelic-n/a",
+			"plan":"standard",
+			"credentials":
+				{
+					"licenseKey":"2865f6f3nsig8f813af7989fccb24a699cb22a4beb"
+				}
+		}
+	]
 }
 ~~~
 For more information, see [VCAP_SERVICES Environment Variable](../../../using/deploying-apps/environment-variable.html).

--- a/source/docs/using/deploying-apps/custom-buildpacks.html.md
+++ b/source/docs/using/deploying-apps/custom-buildpacks.html.md
@@ -38,7 +38,7 @@ The `compile` script builds the droplet that will be run by the DEA and will the
 
 The script is run with two arguments, the build directory for the application and the cache directory, which is a location the buildpack can use to store assets during the build process.
 
-During execution of this script all output sent to STDOUT will be relayed via CF back to the end user. The generally accepted pattern for this is to break out this functionality in to a 'language_pack'. A good example of this can be seen at [https://github.com/cloudfoundry/cloudfoundry-buildpack-java/blob/master/lib/language_pack/java.rb](https://github.com/cloudfoundry/cloudfoundry-buildpack-java/blob/master/lib/language_pack/java.rb)
+During execution of this script all output sent to STDOUT will be relayed via CF back to the end user. The generally accepted pattern for this is to break out this functionality in to a 'language_pack'. A good example of this can be seen at [https://github.com/cloudfoundry/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb](https://github.com/cloudfoundry/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb)
 
 A simple `compile` script is shown below:
 

--- a/source/docs/using/deploying-apps/index.html.md
+++ b/source/docs/using/deploying-apps/index.html.md
@@ -57,7 +57,7 @@ For general intructions on how to push an application to the Pivotal CF hosted s
 
 There are three ways that Cloud Foundry can obtain the command to use to start an application; they are listed below in order of precedence.
 
-1. The value supplied with the `--command` qualifer (or in the application’s `manifest.yml` file). For example, `cf push --command 'java myapp'`.
+1. The value supplied with the `--command` qualifer (or in the application’s `manifest.yml` file). For example, `cf push --command '.java/bin/java myapp'`.
 1. The value of the `web` key in the procfile, for the application, if it exists. A procfile is a text file named `Procfile`, in the root directory of your application, that lists the process types in an application, and associated start commands. For example, `web: YourStartCommand`
 1. The start command (if specified) for the “web” process type, in `default_process_types` section of the output from the buildpack's `bin/release` script. 
 

--- a/source/docs/using/deploying-apps/java-buildpack.html.md
+++ b/source/docs/using/deploying-apps/java-buildpack.html.md
@@ -1,9 +1,9 @@
 ---
-title: About the Java Buildpack  
+title: About the Java Buildpack
 ---
 ## <a id='design-doc'></a>Java Buildpack Documentation ##
 
-For information about using, configuring, and extending the Cloud Foundry Java buildpack, see https://github.com/cloudfoundry/java-buildpack.
+For information about using, configuring, and extending the Cloud Foundry Java buildpack, see <https://github.com/cloudfoundry/java-buildpack>.
 
 For information about the software installed by the Java buildpack, see the following section.
 
@@ -11,19 +11,18 @@ For information about the software installed by the Java buildpack, see the foll
 
 The table below lists:
 
-* **Resource** --- The software installed by the Cloud Foundry Java buildpack, when appropriate.
-* **Available Versions** --- The versions of each software resource that are available from the buildpack.
-* **Installed by Default** --- The version of each software resource that is installed by default. See https://github.com/cloudfoundry/java-buildpack/blob/master/docs/util-repositories.md#version-wildcards for an explanation of the format used to indicate the version in hte "Installed by Default" column. 
-* **To Install a Different Version** --- How to change the buildpack to install a different version of a software resource.
+* **Name** --- The name of the software installed by the Cloud Foundry Java buildpack, when appropriate.
+* **Available Versions** --- The versions of the software that are available from the buildpack.  Note that the available versions may be dependent on the platform that the buildpack is run on.
+* **Installed by Default** --- The version of the software that is installed by default. See https://github.com/cloudfoundry/java-buildpack/blob/master/docs/util-repositories.md#version-wildcards for an explanation of the format used to indicate the version in the "Installed by Default" column.
 
- This page was last updated on July 23, 2013
+ This page was last updated on 19 September, 2013
 
-|Resource |Available Versions |Installed by Default| To Install a Different Version |
-| --------- | --------- | --------- |--------- |
-|OpenJDK | 1.6, 1.7, and 1.8 |1.7.0_+ |Fork the buildpack and edit the `version` property in `config/openjdk.yml`. |
-|Groovy |1.5.0 - 2.1.6 |2.1.+ |Fork the buildpack and edit the `version` property in `config/groovy.yml`. |
-|Tomcat |6.0.0 - 7.0.42 |7.0.+ |Fork the buildpack and edit the `version` property in `config/tomcat.yml`. |
-|Play |Play is compiled into the application |n/a |Install a different version of Play and recompile the application.|
-|Auto-configuration JAR for Spring auto-configuration (Note: This is the same JAR as for Play auto-configuration) |0.6.8 - 0.7.1 |0.+ |Fork the buildpack and edit the `version` property in `config/playautoreconfiguration.yml`  |
-|Auto-configuration JAR for Play auto-configuration (NB. this is the same JAR as for Spring auto-configuration) |0.6.8 - 0.7.1 | 0.+|Fork the buildpack and edit the `version` property in `config/playautoreconfiguration.yml` |
-
+| Name | Available Versions | Installed by Default
+| ---- | ------------------ | --------------------
+| OpenJDK | lucid: [`1.6.0_21 -> 1.8.0_M8`](http://download.pivotal.io.s3.amazonaws.com/openjdk/lucid/x86_64/index.yml)<br>mountainlion: [`1.7.0_04 -> 1.8.0_M8`](http://download.pivotal.io.s3.amazonaws.com/openjdk/mountainlion/x86_64/index.yml)<br>precise: [`1.7.0_01 -> 1.8.0_M8`](http://download.pivotal.io.s3.amazonaws.com/openjdk/precise/x86_64/index.yml) | [`1.7.0_+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/openjdk.yml)
+| Groovy | [`1.5.0 -> 2.1.7`](http://download.pivotal.io.s3.amazonaws.com/groovy/index.yml) | [`2.1.+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/groovy.yml)
+| Spring Boot CLI | [`0.5.0_M2 -> 0.5.0_M4`](http://download.pivotal.io.s3.amazonaws.com/spring-boot-cli/index.yml) | [`0.5.0_+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/springbootcli.yml)
+| Tomcat | [`6.0.0 -> 7.0.42`](http://download.pivotal.io.s3.amazonaws.com/tomcat/index.yml) | [`7.0.+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/tomcat.yml)
+| Auto Reconfiguration | [`0.6.8 -> 0.7.1`](http://download.pivotal.io.s3.amazonaws.com/auto-reconfiguration/index.yml) | [`0.+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/springautoreconfiguration.yml)
+| Play JPA Plugin | [`0.7.1`](http://download.pivotal.io.s3.amazonaws.com/play-jpa-plugin/index.yml) | [`0.+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/playautoreconfiguration.yml)
+| New Relic | [`2.11.0 -> 2.21.4`](http://download.pivotal.io.s3.amazonaws.com/new-relic/index.yml) | [`2.21.+`](https://github.com/cloudfoundry/java-buildpack/blob/master/config/newrelic.yml)


### PR DESCRIPTION
This change polishes up various bits of the Java buildpack documentation.  In particular it focuses on Java buildpack dependencies and simplification of the New Relic instructions to match the zero-touch New Relic support.

[#57268974]

/cc @rmorgan
