### PR TITLE
change deprecated call in fog openstack access test in "Validate your OpenStack" article

### DIFF
--- a/source/docs/running/deploying-cf/openstack/validate_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/validate_openstack.html.md
@@ -46,7 +46,7 @@ Try the following to see if you may be affected by API throttling:
 
 <pre class="terminal">
 $ gem install fog
->> 100.times { p OpenStack.servers }
+>> 100.times { p Compute[:openstack].servers }
 </pre>
 
 If you are running **devstack**, add the following to your `localrc` and at the end of this page you will recreate your devstack without API throttling:
@@ -65,7 +65,7 @@ Verify that you can create a 30G volume:
 $ gem install fog
 $ fog openstack
 >> size = 30
->> v = OpenStack.volumes.create(size: size, name: 'test', description: 'test')
+>> v = Compute[:openstack].volumes.create(size: size, name: 'test', description: 'test')
 >> v.reload
 >> v.status
 "available"


### PR DESCRIPTION
I've got this warning message every time I refer to `OpenStack` object:

```
[WARNING] OpenStack[:compute] is not recommended, use Compute[:openstack] for portability
```

this is fixed by changing it to `Compute[:openstack]`. I use `fog (1.14.0)` gem for the test.

This pull request is covered by contribution agreement between Altoros and Pivotal.
