### PR TITLE
Update install_cf_openstack.html.md

### DIFF
--- a/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
+++ b/source/docs/running/deploying-cf/openstack/install_cf_openstack.html.md
@@ -408,7 +408,6 @@ properties:
 
   cc: &cc
     logging_level: debug
-    external_host: ccng
     srv_api_uri: <%= protocol %>://api.<%= root_domain %>
     cc_partition: default
     db_encryption_key: <%= common_password %>


### PR DESCRIPTION
Removing ccng.external_host from manifest as the default 'api' should apply here in deployments of v146+
