### PR TITLE
Remove purge from list of available bosh-cli commands.

### DIFF
--- a/source/docs/running/bosh/reference/bosh-cli.html.md
+++ b/source/docs/running/bosh/reference/bosh-cli.html.md
@@ -148,9 +148,6 @@ Currently available bosh commands are:
      --tags tag1,tag2... filter by tag
      --all               show all stemcells
 
- purge
-     Purge local manifest cache
-
  recreate <job> [<index>] [--force]
      Recreate job/instance (hard stop + start)
      --force Proceed even when there are other manifest changes


### PR DESCRIPTION
It seems like this is no longer availabe in the current bosh-cli gem.
