### PR TITLE
Added config.ru

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,19 @@
+require "rubygems"
+require "bundler/setup"
+require "middleman-core/load_paths"
+
+Middleman.setup_load_paths
+
+require "middleman-core"
+require "middleman-core/preview_server"
+
+module Middleman::PreviewServer
+  def self.preview_in_rack
+    @options = {  }
+    @app = new_app
+    start_file_watcher
+  end
+end
+
+Middleman::PreviewServer.preview_in_rack
+run Middleman::PreviewServer.app.class.to_rack_app


### PR DESCRIPTION
While we don't use Rack to serve our documentation publicly, being 
Rack-compatible is useful for local development (such as with http://pow.cx). 
This includes the necessary voodoo to make middleman play nicely with Rack.
