### PR TITLE
Create separate page for general info about adding service brokers

### DIFF
--- a/source/docs/running/architecture/services/index.html.md.erb
+++ b/source/docs/running/architecture/services/index.html.md.erb
@@ -32,12 +32,12 @@ The current major version of Service Broker API is v2. Brokers which implement t
 Cloud Foundry currently supports both v2 brokers and v1 brokers, but support for v1 brokers will be removed from the next major version of cloud controller. Although there is no timeline for that release, we recommend new brokers are implemented with the v2 Services API and existing brokers are upgraded. For reference, the [v1 Service Broker API](writing-service-v1.html).
 
 
-### Developing a service broker
+### <a id='developing'></a>Developing a service broker
 1. You'll need a Cloud Foundry instance to deploy and test your service broker as you are developing it. You may use an existing install of CF that you have admin access to. Otherwise, we recommend installing a standalone CF instance using [Bosh Lite](https://github.com/cloudfoundry/bosh-lite).
 2. Read [v2 Service Broker API Documentation](writing-service.html), [Managing Service Brokers on CF](managing-service-brokers.html), and [Using Services](../../../using/services), which explain how to implement and deploy a service broker and how CF uses service brokers to manage services.
 3. Refer to the example service brokers below as a starting point for developing your broker.
 
-### Example Service Brokers
+### <a id='examples'></a>Example Service Brokers
 
 The following example service broker applications have been developed - these are a great starting point if you are developing your own service broker.
 

--- a/source/docs/running/architecture/services/index.html.md.erb
+++ b/source/docs/running/architecture/services/index.html.md.erb
@@ -27,12 +27,31 @@ Because Cloud Foundry only requires that a service implements the broker API in 
 
 The current major version of Service Broker API is v2. Brokers which implement the v2 API are referred to as v2 brokers. All changes to the v2 API will be additive and optional, no endpoints or fields will be removed until the next major version.
 
-* [Writing a Cloud Foundry Service Broker](writing-service.html)
-* [An example Service Broker (GitHub repository service) and demo app that uses the service (written in Ruby)](https://github.com/cloudfoundry-samples/github-service-broker-ruby)
-* [Another example Service Broker (MySQL database service) (written in Ruby)](https://github.com/cloudfoundry/cf-mysql-broker)
-* [Adding a Service Broker on CF](managing-service-broker.html)
+[v2 Service Broker API Documentation](writing-service.html)
 
 Cloud Foundry currently supports both v2 brokers and v1 brokers, but support for v1 brokers will be removed from the next major version of cloud controller. Although there is no timeline for that release, we recommend new brokers are implemented with the v2 Services API and existing brokers are upgraded. For reference, the [v1 Service Broker API](writing-service-v1.html).
+
+### Example Service Brokers
+
+The following example service broker applications have been developed - these are a great starting point if you are developing your own service broker.
+
+#### Ruby
+
+1. [An example Service Broker (GitHub repository service)](https://github.com/cloudfoundry-samples/github-service-broker-ruby) - this is designed to be an easy-to-read example of a service broker, with complete documentation, and comes with a demo app that uses the service.  The broker can be deployed as an application on CF.
+2. [Another example Service Broker (MySQL database service)](https://github.com/cloudfoundry/cf-mysql-broker)
+
+#### Java
+* coming soon
+
+#### Python
+* coming soon
+
+
+### Developer Guide
+* [Bosh Lite setup](https://github.com/cloudfoundry/bosh-lite)
+* [Managing Service Brokers on CF](managing-service-brokers.html)
+* [Managing Services on CF](../../../using/services/managing-services.html)
+
 
 ## <a id='user-provided'></a>User-provided Service Instances ##
 

--- a/source/docs/running/architecture/services/index.html.md.erb
+++ b/source/docs/running/architecture/services/index.html.md.erb
@@ -28,7 +28,9 @@ Because Cloud Foundry only requires that a service implements the broker API in 
 The current major version of Service Broker API is v2. Brokers which implement the v2 API are referred to as v2 brokers. All changes to the v2 API will be additive and optional, no endpoints or fields will be removed until the next major version.
 
 * [Writing a Cloud Foundry Service Broker](writing-service.html)
-* [An example service broker](https://github.com/cloudfoundry/cf-mysql-broker)
+* [An example Service Broker (GitHub repository service) and demo app that uses the service (written in Ruby)](https://github.com/cloudfoundry-samples/github-service-broker-ruby)
+* [Another example Service Broker (MySQL database service) (written in Ruby)](https://github.com/cloudfoundry/cf-mysql-broker)
+* [Adding a Service Broker on CF](managing-service-broker.html)
 
 Cloud Foundry currently supports both v2 brokers and v1 brokers, but support for v1 brokers will be removed from the next major version of cloud controller. Although there is no timeline for that release, we recommend new brokers are implemented with the v2 Services API and existing brokers are upgraded. For reference, the [v1 Service Broker API](writing-service-v1.html).
 

--- a/source/docs/running/architecture/services/index.html.md.erb
+++ b/source/docs/running/architecture/services/index.html.md.erb
@@ -31,6 +31,12 @@ The current major version of Service Broker API is v2. Brokers which implement t
 
 Cloud Foundry currently supports both v2 brokers and v1 brokers, but support for v1 brokers will be removed from the next major version of cloud controller. Although there is no timeline for that release, we recommend new brokers are implemented with the v2 Services API and existing brokers are upgraded. For reference, the [v1 Service Broker API](writing-service-v1.html).
 
+
+### Developing a service broker
+1. You'll need a Cloud Foundry instance to deploy and test your service broker as you are developing it. You may use an existing install of CF that you have admin access to. Otherwise, we recommend installing a standalone CF instance using [Bosh Lite](https://github.com/cloudfoundry/bosh-lite).
+2. Read [v2 Service Broker API Documentation](writing-service.html), [Managing Service Brokers on CF](managing-service-brokers.html), and [Using Services](../../../using/services), which explain how to implement and deploy a service broker and how CF uses service brokers to manage services.
+3. Refer to the example service brokers below as a starting point for developing your broker.
+
 ### Example Service Brokers
 
 The following example service broker applications have been developed - these are a great starting point if you are developing your own service broker.
@@ -45,12 +51,6 @@ The following example service broker applications have been developed - these ar
 
 #### Python
 * coming soon
-
-
-### Developer Guide
-* [Bosh Lite setup](https://github.com/cloudfoundry/bosh-lite)
-* [Managing Service Brokers on CF](managing-service-brokers.html)
-* [Managing Services on CF](../../../using/services/managing-services.html)
 
 
 ## <a id='user-provided'></a>User-provided Service Instances ##

--- a/source/docs/running/architecture/services/managing-service-broker.html.md.erb
+++ b/source/docs/running/architecture/services/managing-service-broker.html.md.erb
@@ -1,0 +1,190 @@
+---
+title: Managing a Cloud Foundry service broker
+---
+
+## Introduction
+
+This document describes how to use the `cf` or `gcf` commanline tools to manage a Cloud Foundry [Service Broker](index.html).
+
+Service Brokers implement the [Service Broker API](writing-service.html).
+
+## <a id='add-broker'></a>Adding a Broker to Cloud Foundry ###
+
+Once you've implemented the [Catalog endpoint](writing-service.html#catalog-mgmt), you'll want to see whether your services and plans are available to end users. Two steps are required: 
+
+1. registering your broker with cloud controller
+2. making plans public.
+
+Before executing these two steps, make sure you are authenticated as a cloud controller admin (via the `cf login` or `gcf login` command).
+
+### <a id='register-broker'></a>Registering a Broker with Cloud Foundry
+
+Registering or updating a broker causes cloud controller to fetch and validate the catalog from your broker, and update the database with any changes found in the catalog.  Registering or updating causes the cloud controller to store the basic auth username and password, which the cloud controller  will send to the broker with every request. Your service broker should validate the username and password sent in every request, otherwise anyone could curl your broker to delete all service instances.
+
+#### To add a broker:
+
+With `cf`:
+
+<pre class="terminal">
+$ cf add-service-broker mybrokername --username someuser --password somethingsecure --url http://mybroker.example.com/
+</pre>
+
+With `gcf`:
+
+<pre class="terminal">
+$ gcf create-service-broker mybrokername someuser somethingsecure http://mybroker.example.com/
+</pre>
+
+#### To update a broker:
+
+With `cf`:
+
+<pre class="terminal">
+$ cf update-service-broker mybrokername --username someuser --password somethingsecure --url http://mybroker.example.com/
+</pre>
+
+With `gcf`:
+
+<pre class="terminal">
+$ gcf update-service-broker mybrokername someuser somethingsecure http://mybroker.example.com/
+</pre>
+
+#### To verify that the broker has been added successfully:
+
+With `cf`:
+
+<pre class="terminal">
+$ cf service-brokers
+Getting service brokers... OK
+
+Name            URL
+my-service-name http://mybroker.example.com
+</pre>
+
+With `gcf`:
+
+<pre class="terminal">
+$ gcf service-brokers
+Getting service brokers as admin...
+OK
+
+Name            URL
+my-service-name http://mybroker.example.com
+</pre>
+
+#### To view services advertised by the broker:
+
+`cf` allows an admin to see services imported from the broker before end users can. `gcf` does not support this. 
+
+<pre class="terminal">
+$ cf services --marketplace
+Getting services... OK
+
+service       	version   provider   plans    	description                                           
+my-service-name n/a       n/a        free-plan	My service description.
+</pre>
+
+
+#### Possible Errors
+
+If  incorrect basic auth credentials are provided:
+
+`cf` returns a unhelpful error: 
+
+<pre class="terminal">
+CFoundry::ServerError: 10001: The service broker API returned an error from http://github-broker.primo.cf-app.com/v2/catalog: 404 Not Found
+</pre>
+
+`gcf` provides a meaningful error:
+
+<pre class="terminal">
+Server error, status code: 500, error code: 10001, message: Authentication failed for the service broker API. Double-check that the username and password are correct: http://github-broker.primo.cf-app.com/v2/catalog
+</pre>
+
+If you receive the following errors, check your broker logs. You may have an internal error.
+
+`cf`:
+
+<pre class="terminal">
+CFoundry::ServerError: 10001: The service broker API returned an error from http://github-broker.primo.cf-app.com/v2/catalog: 500 Internal Server Error
+</pre>
+
+`gcf`:
+
+<pre class="terminal">
+Server error, status code: 500, error code: 10001, message: The service broker API returned an error from http://github-broker.primo.cf-app.com/v2/catalog: 500 Internal Server Error
+</pre>
+
+If your `unique_id`s for service and plan are not unique, you should get an error. Currently these errors aren't helpful, but it's a known issue and will be fixed soon.
+
+`cf`: 
+
+<pre class="terminal">
+CFoundry::InvalidRequest: 10004: The request is invalid
+</pre>
+
+`gcf`:
+
+<pre class="terminal">
+Server error, status code: 400, error code: 10004, message: The request is invalid
+</pre>
+
+
+### <a id='make-plan-public'></a>Making a Plan Public
+
+By default, new plans are private. This means they are not visible to end users. This gives CF admins control over their catalogs when they don't have control over service brokers. Making a plan public currently involves a couple of curls but a CLI command is coming very soon (this command will be implemented in the [v6 Go-based CLI](../../../using/managing-apps/cf/go-cli.html) only).
+
+The first step is to get the service plan guid.
+
+<pre class="terminal">
+$ cf services --marketplace --trace
+</pre>
+
+This will will return a JSON response which will include something like the following for each service.
+
+<pre class="terminal">
+        "service_plans": [
+          {
+            "metadata": {
+              "guid": "a01d462f-a4a4-4945-a008-3ff13c06f719",
+              "url": "/v2/service_plans/a01d462f-a4a4-4945-a008-3ff13c06f719",
+              "created_at": "2013-11-15T23:42:52+00:00",
+              "updated_at": "2013-11-22T18:57:46+00:00"
+            },
+            "entity": {
+              "name": "large",
+              "free": false,
+              "description": "Large Dummy",
+              "service_guid": "e629bb0a-fee7-4a6c-a4f1-9eeec7096c29",
+              "extra": "{\"cost\":20.0,\"bullets\":[]}",
+              "unique_id": "addonOffering_3365",
+              "public": false,
+              "service_url": "/v2/services/e629bb0a-fee7-4a6c-a4f1-9eeec7096c29",
+              "service_instances_url": "/v2/service_plans/a01d462f-a4a4-4945-a008-3ff13c06f719/service_instances"
+            }
+          },
+</pre>
+
+Now run the following curl using the service plan guid above.
+
+<pre class="terminal">
+$ service_plan="a01d462f-a4a4-4945-a008-3ff13c06f719"
+$ cf curl PUT /v2/service_plans/$service_plan -b '{"public":'true'}'
+</pre>
+
+To verify that the the plan was set to public, re-run this command and check the 'public' field:
+
+<pre class="terminal">
+$ cf services --marketplace --trace
+</pre>
+
+At this point you should see your service and plans in the Cloud Foundry Marketplace, or in the response to `gcf marketplace`.
+
+
+### Adding multiple service brokers
+
+Multiple service brokers may be added to a Cloud Foundry, but the following constraints must be kept in mind:
+
+- It's not possible to have multiple brokers with the same name
+- It's not possible to have multiple brokers with the same URL
+- The service id and plan ids of each service advertised by the broker must be unique across Cloud Foundry (GUIDs should be used for these fields)

--- a/source/docs/running/architecture/services/managing-service-brokers.html.md.erb
+++ b/source/docs/running/architecture/services/managing-service-brokers.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Managing a Cloud Foundry service broker
+title: Managing Service Brokers
 ---
 
 ## Introduction

--- a/source/docs/running/architecture/services/managing-service-brokers.html.md.erb
+++ b/source/docs/running/architecture/services/managing-service-brokers.html.md.erb
@@ -8,7 +8,7 @@ This document describes how to use the `cf` or `gcf` commanline tools to manage 
 
 Service Brokers implement the [Service Broker API](writing-service.html).
 
-## <a id='add-broker'></a>Adding a Broker to Cloud Foundry ###
+## <a id='add-broker'></a>Adding a Broker
 
 Once you've implemented the [Catalog endpoint](writing-service.html#catalog-mgmt), you'll want to see whether your services and plans are available to end users. Two steps are required: 
 
@@ -188,3 +188,31 @@ Multiple service brokers may be added to a Cloud Foundry, but the following cons
 - It's not possible to have multiple brokers with the same name
 - It's not possible to have multiple brokers with the same URL
 - The service id and plan ids of each service advertised by the broker must be unique across Cloud Foundry (GUIDs should be used for these fields)
+
+## <a id='list-broker'></a>Listing all Brokers
+
+With `cf`:
+<pre class="terminal">
+$ cf service-brokers
+</pre>
+
+With `gcf`:
+<pre class="terminal">
+$ gcf service-brokers
+</pre>
+
+
+## <a id='remove-broker'></a>Removing a Broker
+
+Any attempt to remove a broker from CF that has associated service instances will fail. When planning to shut down or delete a broker, make sure that you remove it from CF before you shut it down. Failure to do so will leave [orphaned service instances](writing-service.html#orphans).
+
+With `cf`:
+<pre class="terminal">
+$ cf remove-service-broker mybrokername
+</pre>
+
+With `gcf`:
+<pre class="terminal">
+$ gcf delete-service-broker mybrokername
+</pre>
+

--- a/source/docs/running/architecture/services/writing-service.html.md.erb
+++ b/source/docs/running/architecture/services/writing-service.html.md.erb
@@ -194,73 +194,8 @@ CLI and web clients have different needs with regard to service and plan names. 
 
 ### <a id='create-broker'></a>Adding a Broker to Cloud Foundry ###
 
-Once you've implemented the first endpoint `GET /v2/catalog` above, you'll want to see whether your services and plan are available to end users. Two steps are required: registering your broker with cloud controller and making plans public.
+Once you've implemented the first endpoint `GET /v2/catalog` above, you'll want to [register the broker with CF](managing-service-broker.html#add-broker) to make your services and plans available to end users.
 
-Before executing these two steps, make sure you are authenticated as a cloud controller admin (via the `cf login` command).
-
-#### Registering a Broker with Cloud Foundry
-
-Registering or updating a broker causes cloud controller to fetch and validate the catalog from your broker, and update the database with any changes found in the catalog.  Registering or updating causes the cloud controller to store the basic auth username and password, which the cloud controller  will send to the broker with every request. Your service broker should validate the username and password sent in every request, otherwise anyone could curl your broker to delete all service instances.
-
-<pre class="terminal">
-$ cf add-service-broker mybrokername --username someuser --password somethingsecure --url http://mybroker.example.com/
-</pre>
-
-To update a broker:
-
-<pre class="terminal">
-$ cf update-service-broker mybrokername --username someuser --password somethingsecure --url http://mybroker.example.com/
-</pre>
-
-#### Making a Plan Public
-
-By default, new plans are private. This means they are not visible to end users. This gives CF admins control over their catalogs when they don't have control over service brokers. Making a plan public currently involves a couple of curls but a CLI command is coming very soon (this command will be implemented in the [v6 Go-based CLI](../../../using/managing-apps/cf/go-cli.html) only).
-
-The first step is to get the service plan guid.
-
-<pre class="terminal">
-$ cf services -m -t
-</pre>
-
-This will will return a JSON response which will include something like the following for each service.
-
-<pre class="terminal">
-        "service_plans": [
-          {
-            "metadata": {
-              "guid": "a01d462f-a4a4-4945-a008-3ff13c06f719",
-              "url": "/v2/service_plans/a01d462f-a4a4-4945-a008-3ff13c06f719",
-              "created_at": "2013-11-15T23:42:52+00:00",
-              "updated_at": "2013-11-22T18:57:46+00:00"
-            },
-            "entity": {
-              "name": "large",
-              "free": false,
-              "description": "Large Dummy",
-              "service_guid": "e629bb0a-fee7-4a6c-a4f1-9eeec7096c29",
-              "extra": "{\"cost\":20.0,\"bullets\":[]}",
-              "unique_id": "addonOffering_3365",
-              "public": false,
-              "service_url": "/v2/services/e629bb0a-fee7-4a6c-a4f1-9eeec7096c29",
-              "service_instances_url": "/v2/service_plans/a01d462f-a4a4-4945-a008-3ff13c06f719/service_instances"
-            }
-          },
-</pre>
-
-Now run the following curl using the service plan guid above.
-
-<pre class="terminal">
-$ service_plan="a01d462f-a4a4-4945-a008-3ff13c06f719"
-$ cf curl PUT /v2/service_plans/$service_plan -b '{"public":'true'}'
-</pre>
-
-To verify that the the plan was set to public, re-run this command and check the 'public' field:
-
-<pre class="terminal">
-$ cf services -m -t
-</pre>
-
-At this point you should see your service and plans in the Cloud Foundry Marketplace, or in the response to `cf services -m`.
 
 ## <a id='provisioning'></a>Provisioning ##
 

--- a/source/docs/running/architecture/services/writing-service.html.md.erb
+++ b/source/docs/running/architecture/services/writing-service.html.md.erb
@@ -308,7 +308,7 @@ Note that the `:id` of a service binding is provided by the Cloud Controller. `:
 </tbody>
 </table>
 
-Brokers are expected to respond with `200 OK` or `201 Created` with the response body from the table below. They can also return `409 Conflict` if there is already a binding at the URL. Since this endpoint cannot be used to update resources, a broker must return a 409 if a non-identical request is made. If a broker responds with a code other than 200 or 201, Cloud Controller will assume that the binding request failed and inform the user.
+Brokers are expected to respond with `200 OK` or `201 Created` with the response body from the table below. They can also return `409 Conflict` if there is already a binding with the same `id`. Since this endpoint cannot be used to update resources, a broker must return a `409` if an identical request is made. If a broker responds with a code other than `200` or `201`, Cloud Controller will assume that the binding request failed and inform the user.
 
 <table>
 <thead>

--- a/source/docs/running/architecture/services/writing-service.html.md.erb
+++ b/source/docs/running/architecture/services/writing-service.html.md.erb
@@ -194,7 +194,7 @@ CLI and web clients have different needs with regard to service and plan names. 
 
 ### <a id='create-broker'></a>Adding a Broker to Cloud Foundry ###
 
-Once you've implemented the first endpoint `GET /v2/catalog` above, you'll want to [register the broker with CF](managing-service-broker.html#add-broker) to make your services and plans available to end users.
+Once you've implemented the first endpoint `GET /v2/catalog` above, you'll want to [register the broker with CF](managing-service-brokers.html#add-broker) to make your services and plans available to end users.
 
 
 ## <a id='provisioning'></a>Provisioning ##


### PR DESCRIPTION
- populate it with content from the github service broker readme and from writing-service.html
- add links on architecture/services/index to the new "adding service brokers" page and the example (github) service broker
- add "developing a service broker" section to services/index page
- include both cf and gcf commands on these pages
