### PR TITLE
Update instructions for fresh deploy of cf

### DIFF
--- a/source/docs/running/deploying-cf/ec2/index.html.md
+++ b/source/docs/running/deploying-cf/ec2/index.html.md
@@ -25,23 +25,19 @@ Ruby 1.9.3 and git (1.8 or later) are prerequisites for the following steps. Aft
 $ gem install bundler
 </pre>
 
-Create a working directory from which to deploy the environment. For example, `$HOME/cf`. In that directory, create a file named `Gemfile` with the following contents:
+Create a deployments directory with a subdirectory for your particular deployment. For example, `~/deployments/cf-example`. In the particular deployment's sub-directory, create a file named `Gemfile` with the following contents:
 
 ~~~
 source 'https://rubygems.org'
 
 ruby "1.9.3"
 
-gem "bootstrap-cf-plugin", :git => "git://github.com/cloudfoundry/bootstrap-cf-plugin"
-
 gem "bosh_cli_plugin_aws"
 ~~~
 
-Install the latest release of the bootstrap plugin.
-
 <pre class="terminal">
-$ cd $HOME/cf
-~/cf$ bundle install
+$ cd ~/deployments/cf-example
+~/deployments/cf-example$ bundle install
 </pre>
 
 Next, set environment variables required for deploying to AWS. Create a file called `bosh_environment` and add the following, changing the value for each line to suit your configuration:
@@ -49,8 +45,8 @@ Next, set environment variables required for deploying to AWS. Create a file cal
 ~~~
 export BOSH_VPC_DOMAIN=mydomain.com
 export BOSH_VPC_SUBDOMAIN=cloud # Pick something more unique than 'cloud' to work around a temporary shortcoming of the tool
-export BOSH_AWS_ACCESS_KEY_ID=your_key_asdv34tdf
-export BOSH_AWS_SECRET_ACCESS_KEY=your_secret_asdf34dfg
+export BOSH_AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID
+export BOSH_AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY
 export BOSH_AWS_REGION=us-east-1
 export BOSH_VPC_SECONDARY_AZ=us-east-1a # see note below
 export BOSH_VPC_PRIMARY_AZ=us-east-1d   # see note below
@@ -68,13 +64,13 @@ for your region.
 Use `source` to set them for the current shell:
 
 <pre class="terminal">
-~/cf$ source bosh_environment
+~/deployments/cf-example$ source bosh_environment
 </pre>
 
-Run `bosh aws create` to create a VPC Internet Gateway, VPC subnets, 3 RDS databases, and a NAT VM for Cloud Foundry subnet routing. The command does not require user input, so start it and grab a coffee at the trendiest place across town!
+Run `bosh aws create` to create a VPC Internet Gateway, VPC subnets, 3 RDS databases, and a NAT VM for Cloud Foundry subnet routing. The command does not require user input, so start it and grab a coffee at the trendiest place across town! This command will generate receipt files that will be used later when deploying Cloud Foundry (`aws_rds_receipt.yml` and `aws_vpc_receipt.yml`)
 
 <pre class="terminal">
-~/cf$ bosh aws create
+~/cf$ bundle exec bosh aws create
 Executing migration CreateKeyPairs
 allocating 1 KeyPair(s)
 Executing migration CreateVpc
@@ -93,7 +89,7 @@ creating bucket xxxx-bosh-artifacts
 Deploy Micro BOSH from the workspace directory, using the `bosh aws bootstrap micro` command:
 
 <pre class="terminal">
-~/cf$ bosh aws bootstrap micro
+~/deployments/cf-example$ bundle exec bosh aws bootstrap micro
 
 WARNING! Your target has been changed to `https://10.10.0.6:25555'!
 Deployment set to '/Users/pivotal/cf/deployments/micro/micro_bosh.yml'
@@ -112,10 +108,12 @@ User `hm' has been created
 Logged in as `hm'
 </pre>
 
+The command will prompt for a username and password. Choose a username and password that you are going to use later to access your micro bosh installation. 
+
 After Micro BOSH has been deployed succesfully, you can check its status:
 
 <pre class="terminal">
-~/cf$ bosh status
+~/deployments/cf-example$ bundle exec bosh status
 
 Updating director data... done
 
@@ -136,71 +134,260 @@ Deployment
   Manifest   ~/cf/deployments/micro/micro_bosh.yml
 </pre>
 
-## <a id='deploy-cloudfoundry'></a>Deploy Cloud Foundry ##
+## <a id='upload-stemcell'></a>Upload a Stemcell##
 
-Cloud Foundry can now be deployed using the `bundle exec cf bootstrap aws` command from the bootstrap-cf-plugin gem.
+Get the list of available public stemcells.
 
 <pre class="terminal">
-~/cf$ bundle exec cf bootstrap aws
+~/deployments/cf-example$ bundle exec bosh public stemcells
++---------------------------------------------+
+| Name                                        |
++---------------------------------------------+
+| bosh-stemcell-1657-aws-xen-ubuntu.tgz       |
+| bosh-stemcell-1657-aws-xen-centos.tgz       |
+| light-bosh-stemcell-1657-aws-xen-ubuntu.tgz |
+| light-bosh-stemcell-1657-aws-xen-centos.tgz |
+| bosh-stemcell-1657-openstack-kvm-ubuntu.tgz |
+| bosh-stemcell-1657-vsphere-esxi-ubuntu.tgz  |
+| bosh-stemcell-1657-vsphere-esxi-centos.tgz  |
++---------------------------------------------+
+To download use `bosh download public stemcell &lt;stemcell_name&gt;'. For full url use --full.
 </pre>
 
-This process can take some time (2-3 hours), especially during its first run when all the jobs are compiled for the first time. When the bootstrap has finished installing Cloud Foundry, it should be possible to target the install with cf and login as an administrator with the user name `admin` and the password `the_admin_pw`.
-
-If this command fails, it's *usually possible to rerun it again*.  You can also rerun it to deploy the latest version of CF, unless there are changes to the resources created in the "bosh aws create" step above (in which case it should fail).
-
-If this command fails with the following error -  **Error 400007: `service_gateways/0' is not running after update** - your networking is probably not set up correctly. You can check that with the following command (substituting your own subdomain and domain):
+Download the latest ubuntu aws stemcell.
 
 <pre class="terminal">
-~/cf$ curl api.subdomain.domain/info
+~/deployments/cf-example$ bundle exec bosh download public stemcell bosh-stemcell-1657-aws-xen-ubuntu.tgz
+</pre>
+
+Upload the stemcell to the bosh director.
+
+<pre class="terminal">
+~/deployments/cf-example$ bosh upload stemcell ./bosh-stemcell-1657-aws-xen-ubuntu.tgz
+</pre>
+
+## <a id='create-a-stub'></a>Create a Deployment Stub##
+
+Cloud Foundry can now be deployed.
+
+Create a stub file called `cf-aws-stub.yml` for spiff, we'll use this in a moment to generate a BOSH manifest for our CF deployment.
+
+<pre class="terminal">
+---
+name: cf-example
+director_uuid: 80be9b46-435f-41db-96a4-453f8d59f53c
+releases:
+  - name: cf
+    version: latest
+
+properties:
+  template_only:
+    aws:
+      access_key_id: PLACEHOLDER-ACCESS-KEY-ID
+      secret_access_key: PLACEHOLDER-SECRET-KEY
+      availability_zone: us-east-1a # Change this if you'd like to
+      availability_zone2: us-east-1b # Change this if you'd like to
+      subnet_ids:
+        cf1: PLACEHOLDER-SUBNET-FOR-AZ1
+        cf2: PLACEHOLDER-SUBNET-FOR-AZ2
+
+  domain: PLACEHOLDER-DOMAIN
+
+  nats:
+    user: PLACEHOLDER-NATS-USER
+    password: PLACEHOLDER-NATS-PASSWORD
+
+  cc:
+    db_encryption_key: PLACEHOLDER-CC-DB-ENCRYPTION-KEY
+    bulk_api_password: PLACEHOLDER-BULK-API-PASSWORD
+    staging_upload_password: PLACEHOLDER-STAGING-UPLOAD-PASSWORD
+    staging_upload_user: PLACEHOLDER-STAGING-UPLOAD-USER
+
+  uaa:
+    scim:
+      users:
+      - admin|the_admin_pw|scim.write,scim.read,openid,cloud_controller.admin         #change if you like
+      - services|the_services_pw|scim.write,scim.read,openid,cloud_controller.admin   #change if you like
+    admin:
+      client_secret: PLACEHOLDER-UAA-ADMIN-CLIENT-SECRET
+    jwt:
+      signing_key: PLACEHOLDER-UAA-JWT-SIGNING-KEY
+      verification_key: PLACEHOLDER-UAA-JWT-VERIFICATION-KEY
+    clients:
+      login:
+        secret: PLACEHOLDER-UAA-CLIENTS-LOGIN-SECRET
+      developer_console:
+        secret: PLACEHOLDER-UAA-CLIENTS-DEVELOPER-CONSOLE-SECRET
+      app-direct:
+        secret: PLACEHOLDER-UAA-CLIENTS-APP-DIRECT-SECRET
+      support-services:
+        secret: PLACEHOLDER-UAA-CLIENTS-SUPPORT-SERVICES-SECRET
+      servicesmgmt:
+        secret: PLACEHOLDER-UAA-CLIENTS-SERVICESMGMT-SECRET
+      space-mail:
+        secret: PLACEHOLDER-UAA-CLIENTS-SPACE-MAIL-SECRET
+    batch:
+      username: PLACEHOLDER-UAA-BATCH-USERNAME
+      password: PLACEHOLDER-UAA-BATCH-PASSWORD
+    cc:
+      client_secret: PLACEHOLDER-UAA-CC-CLIENT-SECRET
+
+  uaadb: PLACEHOLDER_UAADB_PROPERTIES
+  ccdb: PLACEHOLDER_CCDB_PROPERTIES
+
+  router:
+    status:
+      user: PLACEHOLDER-ROUTER-STATUS-USER
+      password: PLACEHOLDER-ROUTER-STATUS-PASSWORD
+
+  dea_next:
+    disk_mb: 400001
+    memory_mb: 6656
+
+  loggregator_endpoint:
+    shared_secret: PLACEHOLDER-LOGGREGATOR-SECRET
+</pre>
+
+Replace placeholders with the approriate data:
+
+- `PLACEHOLDER-DIRECTOR-UUID` - the bosh director UUID. You can get it by running `bundle exec bosh status`.
+
+- `PLACEHOLDER-ACCESS-KEY-ID` and `PLACEHOLDER-SECRET-KEY` - AWS access key id and secret key. You can use the same ones as you used in the `bosh_environment` file above, or generate new ones.
+
+- `PLACEHOLDER-AWS-AVAILABILITY-ZONE` and `PLACEHOLDER-AWS-AVAILABILITY-ZONE2` - `BOSH_VPC_PRIMARY_AZ` and `BOSH_VPC_SECONDARY_AZ` from the `bosh_environment` file above.
+
+- `PLACEHOLDER-SUBNET-FOR-AZ1` and `PLACEHOLDER-SUBNET-FOR-AZ2` - Look in `~/deployments/cf-example/aws_vpc_receipt.yml` (this file was generated when you ran `bosh aws create`).  They are under 'subnets' 'cf1' and 'cf2'.
+
+- `PLACEHOLDER-DOMAIN` - `BOSH_VPC_SUBDOMAIN.BOSH_VPC_DOMAIN` from the `bosh_environment` file above (hosted domain created in route 53).
+
+- `PLACEHOLDER-UAADB-PROPERTIES`, `PLACEHOLDER-CCDB-PROPERTIES` - copy these from `~/deployments/cf-example/aws_rds_receipt.yml` 
+
+Generate secure keys for the following placeholders:
+
+- `PLACEHOLDER-NATS-USER`
+
+- `PLACEHOLDER-NATS-PASSWORD`
+
+- `PLACEHOLDER-CC-DB-ENCRYPTION-KEY`
+
+- `PLACEHOLDER-BULK-API-PASSWORD`
+
+- `PLACEHOLDER-CC-STAGING-UPLOAD-USER`
+
+- `PLACEHOLDER-CC-STAGING-UPLOAD-PASSWORD`
+
+- `PLACEHOLDER-UAA-ADMIN-CLIENT-SECRET`
+
+- `PLACEHOLDER-UAA-CLIENTS-LOGIN-SECRET`
+
+- `PLACEHOLDER-UAA-CLIENTS-DEVELOPER-CONSOLE-SECRET`
+
+- `PLACEHOLDER-UAA-CLIENTS-APP-DIRECT-SECRET`
+
+- `PLACEHOLDER-UAA-CLIENTS-SUPPORT-SERVICES-SECRET`
+
+- `PLACEHOLDER-UAA-CLIENTS-SERVICESMGMT-SECRET`
+
+- `PLACEHOLDER-UAA-CLIENTS-SPACE-MAIL-SECRET`
+
+- `PLACEHOLDER-UAA-BATCH-USERNAME`
+
+- `PLACEHOLDER-UAA-BATCH-PASSWORD`
+
+- `PLACEHOLDER-UAA-CC-CLIENT-SECRET`
+
+- `PLACEHOLDER-ROUTER-STATUS-USER`
+
+- `PLACEHOLDER-ROUTER-STATUS-PASSWORD`
+
+- `PLACEHOLDER-LOGGREGATOR-SECRET`
+
+
+Generate RSA key pair for:
+
+- `PLACEHOLDER-UAA-JWT-SIGNING-KEY` and `PLACEHOLDER-UAA-JWT-VERIFICATION-KEY`
+
+You can also replace the users username/password in uaa->scim->users list.
+
+
+## <a id='deploy-cloudfoundry'></a>Deploy Cloud Foundry##
+
+Clone `cf-release` into a convenient location, e.g. `~/releases/cf-release`
+
+<pre class="terminal">
+~/releases$ git clone https://github.com/cloudfoundry/cf-release.git
+</pre>
+
+Update cf-release submodules. You can use helper script `update` in cf-release. 
+
+<pre class="terminal">
+~/releases$ cd cf-release
+~/releases/cf-release$ ./update
+</pre>
+
+Install spiff using instructions from the [Spiff Readme](https://github.com/cloudfoundry-incubator/spiff).
+
+Generate a BOSH deployment manifest:
+
+<pre class="terminal">
+~/releases/cf-release$ ./generate_deployment_manifest aws templates/cf-minimal-dev.yml ~/deployments/cf-example/cf-aws-stub.yml > ~/deployments/cf-example/cf.yml
+</pre>
+
+Deploy CF using BOSH.
+
+<pre class="terminal">
+~/releases/cf-release$ bundle install
+</pre>
+
+Check that you are still targetted at your new bosh director.
+<pre class="terminal">
+~/releases/cf-release$ bundle exec bosh target
+Current target is https://x.x.x.x:25555 (micro-xxxxxx)
+</pre>
+If this doesn't match then name of your deployed micro bosh you can target director using IP from `~/deployments/micro/micro_bosh.yml`.
+
+Set your deployment to the generated manifest
+<pre class="terminal">
+~/releases/cf-release$ bundle exec bosh deployment ~/deployments/cf-example/cf.yml
+</pre>
+
+Create a Cloud Foundry release. It will prompt you for a development release name.  You can use `cf` which was specified in deployment manifest under releases->name.
+
+<pre class="terminal">
+~/releases/cf-release$ bundle exec bosh create release
+</pre>
+
+Upload the generated release to the BOSH director.
+
+<pre class="terminal">
+~/releases/cf-release$ bundle exec bosh upload release
+</pre>
+
+Deploy the uploaded Cloud Foundry release.
+
+<pre class="terminal">
+~/releases/cf-release$ bundle exec bosh deploy
+</pre>
+
+This process can take some time (2-3 hours), especially during its first run when all the jobs are compiled for the first time. If `bosh deploy` fails, it's *usually possible to rerun it again*. 
+
+To test Cloud Foundry installation test the API endpoint.
+
+<pre class="terminal">
+~/releases/cf-release$ curl api.subdomain.domain/info
 </pre>
 
 If that is successful it should return the information as json. Otherwise, check your networking. *Tip* - make sure your domain has an NS record for your subdomain.
 
-This bootstrap command runs two phases: first, several BOSH commands are executed and then several CF commands are executed. At the end of the process, you have the following primitives:
+At this point it should be possible to target the install with [gcf](https://github.com/cloudfoundry/cli) and login as an administrator with the user name `admin` and the password `the_admin_pw` used in the deployiment manifest under uaa->scim->users. For more information about managing organizations, spaces, and users and applications go to the [gcf](https://github.com/cloudfoundry/cli) page.
 
-+ 2 BOSH releases: cf-release and cf-services-release, each pulled from the latest "green" release-candidate branch in github.
-+ The latest "green" BOSH stemcell, downloaded from our CI server.
-+ 2 already-deployed BOSH deployments: CF core and CF services, backed by generated manifest files described below.
-+ 2 CF admin user accounts with randomly-generated passwords (find in cf-shared-secrets.yml).
-+ A default CF organization called "bootstrap-org".
-+ A default CF space called "bootstrap-space".
-+ CF service-auth-tokens allowing CF core to authenticate to CF services.
+If you want to update your deploy of cf-release to reflect changes in the cf-release directory you can run `bosh create release && bosh upload release && bosh deploy` again. If you only have changes in your manifest you can just run `bosh deploy`. 
 
-At this point your "cf" command-line tool is targeted to your CF deployment and you are authenticated as the admin user, meaning _you're ready to push an app_!
+## <a id='deploy-cloudfoundry-services'></a>Deploy Cloud Foundry Services##
 
-## <a id='deploy-notes'></a> BOSH Deployment Notes ##
+If you want your Cloud Foundry to be able to provision services you would need to deploy services release. Check the instructions on how to create a service broker [here](http://docs.cloudfoundry.com/docs/running/architecture/services/writing-service.html).
 
-Once Cloud Foundry has been deployed using the bootstrap cf plugin, there will be several files left in the `$HOME/cf` folder:
-
-<table>
-  <tr><th>File</th><th>Purpose</th></tr>
-  <tr>
-    <td>cf-aws.yml</td>
-    <td>BOSH manifest file for Cloud Foundry that was used to deploy to AWS. You can use this file to redeploy the Cloud Foundry instance again. For more information, see <a href="">managing BOSH deployments</a>.</td>
-  </tr>
-  <tr>
-    <td>cf-services-aws.yml</td>
-    <td>BOSH manifest file for Cloud Foundry services.
-  </tr>
-  <tr>
-    <td>cf-shared-secrets.yml</td>
-    <td>Shared secrets file for usernames and passwords used in various Cloud Foundry components.</td>
-  </tr>
-  <tr>
-    <td>director.key and director.pem</td>
-    <td>Self-signed SSL certificate used to encrypt the connection between BOSH CLI and Micro BOSH.</td>
-  </tr>
-  <tr>
-    <td>elb-cfrouter.key and elb-cfrouter.pem</td>
-    <td>Self-signed SSL certificate installed on the AWS ELB that fronts the Cloud Foundry routing layer.</td>
-  </tr>
-  <tr>
-    <td>aws_rds_receipt.yml, aws_route53_receipt.yml, aws_vpc_receipt.yml</td>
-    <td>At the end of the MicroBOSH bootstrapping procedure, these 'receipt' files are written to provide data used to template the manifest file used for deploying Cloud Foundry.</td>
-  </tr>
-</table>
-
-For more information about managing organizations, spaces, and users, go to the [cf](../../../using/managing-apps/cf/index.html) page.
+You also might be interested in checking out [community managed services release](https://github.com/cloudfoundry/cf-services-contrib-release).
 
 ## <a id='destroy-environment'></a>Destroying the AWS Environment ##
   <table style="width: 70%;"><tr><td>
@@ -210,6 +397,6 @@ For more information about managing organizations, spaces, and users, go to the 
 You also want to cleanup any YAML artifacts that are no longer valid:
 
 <pre class="terminal">
-~/cf$ bosh aws destroy
-~/cf$ rm -f *.yml
+~/deployments/cf-example$ bundle exec bosh aws destroy
+~/deployments/cf-example$ rm -f *.yml
 </pre>


### PR DESCRIPTION
We used to do this using the cf-aws-bootstrap plugin.  That no longer
works, so we've documented a manual deploy procedure using spiff here.

No longer deploys services; the release that the old plugin was
deploying is now deprecated.

Signed-off-by: Abhijit Hiremagalur abhi@pivotallabs.com
Signed-off-by: Maria Shaldibina mariash@pivotallabs.com
