### PR TITLE
Fixing bosh deployment instructions for vcloud

### DIFF
--- a/source/docs/running/deploying-cf/vcloud/deploying_to_vcloud_director.md
+++ b/source/docs/running/deploying-cf/vcloud/deploying_to_vcloud_director.md
@@ -11,11 +11,9 @@ To get started with BOSH on vCloud you need:
 3. A Mac or *NIX computer
 4. The [BOSH CLI](../../bosh/setup/index.html)
 
-##Installing the BOSH Deployer##
+## Installing micro bosh
 
-We assume you already have Ruby (1.9.2) and rubygems (1.8) installed. To install the BOSH deployer gem (which includes the BOSH CLI):
-
-	gem install bosh_deployer
+Note: this part is common with most other IaaS. Please refer to more common IaaS whose documentation is more up-to-date, such as [Deploy Micro BOSH using vSphere](../vpshere/deploying_micro_bosh.html)
 
 ## Micro BOSH Stemcells##
 
@@ -65,11 +63,14 @@ The BOSH deployer will deploy applications based on files in expected directory 
 
 Micro BOSH configurations are set in the `micro_bosh.yml`, which you need to create.
 
-+ Create `~/deployments/vcloud/micro_bosh.yml` using [this template](../micro_bosh-vcloud.yml).
++ Create `~/deployments/vcloud/micro_bosh.yml` using [this template](micro_bosh-vcloud.yml).
 
    1. Update the instance of `x.x.x.x` with one of the IPs from the block assigned to you. Change the other IP addresses `n.n.n.n`  to match your network’s netmask, gateway, DNS and NTP server addresses.
    2. Under the vcds section, replace `v.v.v.v` with the address of the vCloud instance and enter your vCloud credentials.
-   3. Save the file
+   3. change the cloud_properties name:cf-net to the name of the external network
+   4. you may choose to have your micro_bosh deploy on a distinct vcloud instance that the one it is running on. If so,
+   change the apply_spec/properties/cloud section.
+   5. Save the file
 
 ##Deploying Micro BOSH##
 

--- a/source/docs/running/deploying-cf/vcloud/micro_bosh-vcloud.yml
+++ b/source/docs/running/deploying-cf/vcloud/micro_bosh-vcloud.yml
@@ -13,7 +13,11 @@ network:
     name: cf-net
 
 resources:
-  persistent_disk: 4096
+  persistent_disk: 16384
+  cloud_properties:
+    ram: 8192
+    disk: 16384
+    cpu: 4
 
 cloud:
   plugin: vcloud

--- a/source/docs/running/deploying-cf/vsphere/deploying_micro_bosh.md
+++ b/source/docs/running/deploying-cf/vsphere/deploying_micro_bosh.md
@@ -149,6 +149,10 @@ If you have 2 datastores called "vnx:1" and "vnx:2", and you would like to separ
 
 Download a BOSH Stemcell:
 
+You need internet access for the bosh_cli to download the stemcells. You may need to temporary set the http_proxy and
+https_proxy variables if you're running behind a corporate firewall. If so, remember to unset it before completing
+ the following steps, if your proxy won't allow contacting the newly micro_bosh vm.
+
 <pre class="terminal">
 $ bosh public stemcells
 +---------------------------------------------+


### PR DESCRIPTION
Fix for https://github.com/cloudfoundry/cf-docs/issues/271

Instructed to refer to vsphere micro bosh deployment which is up-to-date. This aims to avoid duplication. Used sensible vm sizing for microbosh in micro_bosh-vcloud.yml.
Added a mention about http_proxy into deploying_micro_bosh.md
