### PR TITLE
Precising configuration of DNS to deploy CF release, and IP semantics.

### DIFF
--- a/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md
+++ b/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md
@@ -30,14 +30,21 @@ networks:
 - name: default
   subnets:
   - range: 172.16.214.0/23
+    #Reversed are the IPs that bosh should not be using in the declared range
     reserved:
     - 172.16.214.2 - 172.16.214.9
     - 172.16.215.245 - 172.16.215.254
+    #Static are the ones that are statically assigned to jobs in this manifest, and that bosh director will not attempt
+    #to dynamically assign to new vms.
     static:
     - 172.16.214.10 - 172.16.214.140
     gateway: 172.16.214.1
-    dns:
-    - 8.8.8.8
+    #If you configured your bosh/micro-bosh to enable dns, then leave the dns section empty. Bosh director
+    #will automatically use the bosh/micro-bosh powerDNS IP. If ever some of the jobs need to resolve DNS
+    #entries outside the bosh powerDNS subdomain (*.microbosh by default) then configure the powerDNS recursor
+    #in your bosh release.
+    #dns:
+    #- 8.8.8.8
     cloud_properties:
       name: default_vlan
 - name: lb

--- a/source/docs/running/deploying-cf/vsphere/deploying_micro_bosh.md
+++ b/source/docs/running/deploying-cf/vsphere/deploying_micro_bosh.md
@@ -70,6 +70,8 @@ network:
   netmask: <netmask_for_the_subnet_you_are_deploying_to>
   gateway: <gateway_for_the_subnet_you_are_deploying_to>
   dns:
+  #The micro-bosh VM will have the following DNS entries in its /etc/resolv.com
+  #e.g. allowing it to resolve IaaS FQDNs
   - <ip_for_dns>
   cloud_properties:
     name: <network_name_according_to_vsphere>
@@ -120,6 +122,10 @@ apply_spec:
           clusters:
           - <cluster_name>:
               resource_pool: <resource_pool_name_optional>
+    dns:
+        #the bosh powerDNS will contact the following DNS server for serving DNS entries from other domains
+        recursor: <ip_for_dns>
+
 
 ~~~
 


### PR DESCRIPTION
micro bosh should have recursor configured so that DEA are able to resolve DNS entries their app will require.
CF deployment should not list dns entries into their cloud properties and rather rely on the bosh powerDNS.
Precised semantics of reserved and static section in networks

Contributes to fixing https://github.com/cloudfoundry/cf-docs/issues/271
