### PR TITLE
Add reference to Cf job specs that document the semantics of properties and mention of automatic generation of such manifest

### DIFF
--- a/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md
+++ b/source/docs/running/deploying-cf/vsphere/cloud-foundry-example-manifest.md
@@ -2,6 +2,10 @@
 title: Cloud Foundry Example Manifest
 ---
 
+This is an example manifest. Usually such manifest are not manually crafted but rather "compiled" from templates, see [cf-release](https://github.com/cloudfoundry/cf-release) ```generate_deployment_manifest```
+
+Note that detailed documentation of job-related properties is available within [cf-release](https://github.com/cloudfoundry/cf-release) in the ```jobs/job_name/spec``` file in its ```properties``` section, such as [CC specs](https://github.com/cloudfoundry/cf-release/blob/master/jobs/cloud_controller_ng/spec)
+
 ~~~yaml
 ---
 name: your-deployment


### PR DESCRIPTION
Add reference to Cf job specs that document the semantics of properties and mention of automatic generation of such manifest
