### PR TITLE
Fixing default UAA admin authorities

### DIFF
--- a/source/docs/running/managing-cf/managing-users.html.md
+++ b/source/docs/running/managing-cf/managing-users.html.md
@@ -4,6 +4,9 @@ title: Managing Users
 
 This document is a temporary description for Cloud Foundry operators and dev / ops professionals interested in managing users in a new Cloud Foundry installation. This process is unrefined, and will improve with direct cf user management in the near future.
 
+You may refer to [the UAA admin guide](https://github.com/cloudfoundry/uaa/blob/master/docs/Sysadmin-Guide.rst), [other UAA documentation](https://github.com/cloudfoundry/uaa/tree/master/docs) for additional details,
+or to the [UAA introduction](../architecture/uaa.html.html)
+
 ## <a id='creating-admin-users'></a> Creating Admin Users ##
 
 1. Refer to your deployment manifest for the uaa:admin:client_secret. Refer to this [manifest](../deploying-cf/vsphere/cloud-foundry-example-manifest.html) as an example.

--- a/source/docs/running/managing-cf/managing-users.html.md
+++ b/source/docs/running/managing-cf/managing-users.html.md
@@ -19,6 +19,16 @@ $ uaac target uaa.[your-domain].com
 $ uaac token client get admin -s [admin-client-secret]
 </pre class="terminal">
 
+3. Check sufficient permissions for admin to create account, in particular scim.write, if not add this permission and renew token:
+<pre class="terminal">
+$ uaac contexts
+[...]
+  scope: password.write clients.write clients.read scim.read uaa.admin clients.secret
+$ uaac client update admin --authorities "password.write clients.write clients.read scim.read uaa.admin clients.secret scim.write"
+$ uaac token delete
+$ uaac token client get admin
+</pre class="terminal">
+
 4. Create an admin user and add them to the admin group:
 <pre class="terminal">
 $ uaac user add [admin-username] -p [admin-password] --emails [admin-user-email-address]


### PR DESCRIPTION
As to avoid access_denied when trying to create a new admin user

See related thread at https://groups.google.com/a/cloudfoundry.org/d/msg/vcap-dev/q9HlwPAPBTw/Aa3slgliuu8J
